### PR TITLE
Update visability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   </developers>
 
   <properties>
-    <aws-java-sdk.version>1.10.27</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.300</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -30,6 +30,7 @@ import java.util.Map.Entry;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -911,7 +912,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 				SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER);
 		String s3MsgKey = getFromReceiptHandleByMarker(receiptHandle, SQSExtendedClientConstants.S3_KEY_MARKER);
 		try {
-			clientConfiguration.getAmazonS3Client().deleteObject(s3MsgBucketName, s3MsgKey);
+			clientConfiguration.getAmazonS3Client().deleteObject(new DeleteObjectRequest(s3MsgBucketName, s3MsgKey));
 		} catch (AmazonServiceException e) {
 			String errorMessage = "Failed to delete the S3 object which contains the SQS message payload. SQS message was not deleted.";
 			LOG.error(errorMessage, e);

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -37,7 +37,35 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.*;
+
+import com.amazonaws.services.sqs.model.BatchEntryIdsNotDistinctException;
+import com.amazonaws.services.sqs.model.BatchRequestTooLongException;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequest;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchResult;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchResult;
+import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import com.amazonaws.services.sqs.model.EmptyBatchRequestException;
+import com.amazonaws.services.sqs.model.InvalidBatchEntryIdException;
+import com.amazonaws.services.sqs.model.InvalidIdFormatException;
+import com.amazonaws.services.sqs.model.InvalidMessageContentsException;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.amazonaws.services.sqs.model.MessageNotInflightException;
+import com.amazonaws.services.sqs.model.OverLimitException;
+import com.amazonaws.services.sqs.model.PurgeQueueRequest;
+import com.amazonaws.services.sqs.model.ReceiptHandleIsInvalidException;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.SendMessageBatchResult;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import com.amazonaws.services.sqs.model.TooManyEntriesInBatchRequestException;
 
 import com.amazonaws.util.Base16;
 import com.amazonaws.util.Base64;
@@ -48,12 +76,12 @@ import org.apache.commons.logging.LogFactory;
  * Amazon SQS Extended Client extends the functionality of Amazon SQS client.
  * All service calls made using this client are blocking, and will not return
  * until the service call completes.
- * <p/>
+ *
  * <p>
  * The Amazon SQS extended client enables sending and receiving large messages
  * via Amazon S3. You can use this library to:
  * </p>
- * <p/>
+ *
  * <ul>
  * <li>Specify whether messages are always stored in Amazon S3 or only when a
  * message size exceeds 256 KB.</li>
@@ -72,12 +100,13 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * Constructs a new Amazon SQS extended client to invoke service methods on
 	 * Amazon SQS with extended functionality using the specified Amazon SQS
 	 * client object.
-	 * <p/>
-	 * <p/>
+	 *
+	 * <p>
 	 * All service calls made using this new client object are blocking, and
 	 * will not return until the service call completes.
 	 *
-	 * @param sqsClient The Amazon SQS client to use to connect to Amazon SQS.
+	 * @param sqsClient
+	 *            The Amazon SQS client to use to connect to Amazon SQS.
 	 */
 	public AmazonSQSExtendedClient(AmazonSQS sqsClient) {
 		this(sqsClient, new ExtendedClientConfiguration());
@@ -87,13 +116,15 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * Constructs a new Amazon SQS extended client to invoke service methods on
 	 * Amazon SQS with extended functionality using the specified Amazon SQS
 	 * client object.
-	 * <p/>
-	 * <p/>
+	 *
+	 * <p>
 	 * All service calls made using this new client object are blocking, and
 	 * will not return until the service call completes.
 	 *
-	 * @param sqsClient            The Amazon SQS client to use to connect to Amazon SQS.
-	 * @param extendedClientConfig The extended client configuration options controlling the
+	 * @param sqsClient
+	 *            The Amazon SQS client to use to connect to Amazon SQS.
+	 * @param extendedClientConfig
+	 *            The extended client configuration options controlling the
 	 *                             functionality of this client.
 	 */
 	public AmazonSQSExtendedClient(AmazonSQS sqsClient, ExtendedClientConfiguration extendedClientConfig) {
@@ -113,19 +144,25 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * characters not included in the list, your request will be rejected. #x9 |
 	 * #xA | #xD | [#x20 to #xD7FF] | [#xE000 to #xFFFD] | [#x10000 to #x10FFFF]
 	 * </p>
-	 * <p/>
+	 *
 	 * <b>IMPORTANT:</b> The input object may be modified by the method. </p>
 	 *
-	 * @param sendMessageRequest Container for the necessary parameters to execute the
+	 * @param sendMessageRequest
+	 *            Container for the necessary parameters to execute the
 	 *                           SendMessage service method on AmazonSQS.
+	 *
 	 * @return The response from the SendMessage service method, as returned by
 	 * AmazonSQS.
+	 *
 	 * @throws InvalidMessageContentsException
 	 * @throws UnsupportedOperationException
-	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                         while attempting to make the request or handle the response.
 	 *                                         For example if a network connection is not available.
-	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                         either a problem with the data in the request, or a server
 	 *                                         side issue.
 	 */
@@ -168,17 +205,24 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * #xA | #xD | [#x20 to #xD7FF] | [#xE000 to #xFFFD] | [#x10000 to #x10FFFF]
 	 * </p>
 	 *
-	 * @param queueUrl    The URL of the Amazon SQS queue to take action on.
-	 * @param messageBody The message to send. For a list of allowed characters, see the
+	 * @param queueUrl
+	 *            The URL of the Amazon SQS queue to take action on.
+	 * @param messageBody
+	 *            The message to send. For a list of allowed characters, see the
 	 *                    preceding important note.
+	 *
 	 * @return The response from the SendMessage service method, as returned by
 	 * AmazonSQS.
+	 *
 	 * @throws InvalidMessageContentsException
 	 * @throws UnsupportedOperationException
-	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                         while attempting to make the request or handle the response.
 	 *                                         For example if a network connection is not available.
-	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                         either a problem with the data in the request, or a server
 	 *                                         side issue.
 	 */
@@ -211,7 +255,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * For each message returned, the response includes the following:
 	 * </p>
-	 * <p/>
+	 *
 	 * <ul>
 	 * <li>
 	 * <p>
@@ -245,7 +289,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * MD5 digest of the message attributes.
 	 * </p>
 	 * </li>
-	 * <p/>
+	 *
 	 * </ul>
 	 * <p>
 	 * The receipt handle is the identifier you must provide when deleting the
@@ -269,15 +313,21 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * code so that it can handle new attributes gracefully.
 	 * </p>
 	 *
-	 * @param receiveMessageRequest Container for the necessary parameters to execute the
+	 * @param receiveMessageRequest
+	 *            Container for the necessary parameters to execute the
 	 *                              ReceiveMessage service method on AmazonSQS.
+	 *
 	 * @return The response from the ReceiveMessage service method, as returned
 	 * by AmazonSQS.
+	 *
 	 * @throws OverLimitException
-	 * @throws AmazonClientException  If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                while attempting to make the request or handle the response.
 	 *                                For example if a network connection is not available.
-	 * @throws AmazonServiceException If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                either a problem with the data in the request, or a server
 	 *                                side issue.
 	 */
@@ -358,7 +408,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * For each message returned, the response includes the following:
 	 * </p>
-	 * <p/>
+	 *
 	 * <ul>
 	 * <li>
 	 * <p>
@@ -392,7 +442,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * MD5 digest of the message attributes.
 	 * </p>
 	 * </li>
-	 * <p/>
+	 *
 	 * </ul>
 	 * <p>
 	 * The receipt handle is the identifier you must provide when deleting the
@@ -416,14 +466,20 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * code so that it can handle new attributes gracefully.
 	 * </p>
 	 *
-	 * @param queueUrl The URL of the Amazon SQS queue to take action on.
+	 * @param queueUrl
+	 *            The URL of the Amazon SQS queue to take action on.
+	 *
 	 * @return The response from the ReceiveMessage service method, as returned
 	 * by AmazonSQS.
+	 *
 	 * @throws OverLimitException
-	 * @throws AmazonClientException  If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                while attempting to make the request or handle the response.
 	 *                                For example if a network connection is not available.
-	 * @throws AmazonServiceException If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                either a problem with the data in the request, or a server
 	 *                                side issue.
 	 */
@@ -461,14 +517,20 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * once is not a problem.
 	 * </p>
 	 *
-	 * @param deleteMessageRequest Container for the necessary parameters to execute the
+	 * @param deleteMessageRequest
+	 *            Container for the necessary parameters to execute the
 	 *                             DeleteMessage service method on AmazonSQS.
+	 *
+	 *
 	 * @throws ReceiptHandleIsInvalidException
 	 * @throws InvalidIdFormatException
-	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                         while attempting to make the request or handle the response.
 	 *                                         For example if a network connection is not available.
-	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                         either a problem with the data in the request, or a server
 	 *                                         side issue.
 	 */
@@ -526,16 +588,23 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * once is not a problem.
 	 * </p>
 	 *
-	 * @param queueUrl      The URL of the Amazon SQS queue to take action on.
-	 * @param receiptHandle The receipt handle associated with the message to delete.
+	 * @param queueUrl
+	 *            The URL of the Amazon SQS queue to take action on.
+	 * @param receiptHandle
+	 *            The receipt handle associated with the message to delete.
+	 *
 	 * @return The response from the DeleteMessage service method, as returned
 	 * by AmazonSQS.
+	 *
 	 * @throws ReceiptHandleIsInvalidException
 	 * @throws InvalidIdFormatException
-	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                         while attempting to make the request or handle the response.
 	 *                                         For example if a network connection is not available.
-	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                         either a problem with the data in the request, or a server
 	 *                                         side issue.
 	 */
@@ -581,20 +650,26 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param sendMessageBatchRequest Container for the necessary parameters to execute the
+	 * @param sendMessageBatchRequest
+	 *            Container for the necessary parameters to execute the
 	 *                                SendMessageBatch service method on AmazonSQS.
+	 *
 	 * @return The response from the SendMessageBatch service method, as
 	 * returned by AmazonSQS.
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws BatchRequestTooLongException
 	 * @throws UnsupportedOperationException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                               while attempting to make the request or handle the response.
 	 *                                               For example if a network connection is not available.
-	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                               either a problem with the data in the request, or a server
 	 *                                               side issue.
 	 */
@@ -661,20 +736,27 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param queueUrl The URL of the Amazon SQS queue to take action on.
-	 * @param entries  A list of <a>SendMessageBatchRequestEntry</a> items.
+	 * @param queueUrl
+	 *            The URL of the Amazon SQS queue to take action on.
+	 * @param entries
+	 *            A list of <a>SendMessageBatchRequestEntry</a> items.
+	 *
 	 * @return The response from the SendMessageBatch service method, as
 	 * returned by AmazonSQS.
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws BatchRequestTooLongException
 	 * @throws UnsupportedOperationException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                               while attempting to make the request or handle the response.
 	 *                                               For example if a network connection is not available.
-	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                               either a problem with the data in the request, or a server
 	 *                                               side issue.
 	 */
@@ -707,18 +789,24 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param deleteMessageBatchRequest Container for the necessary parameters to execute the
+	 * @param deleteMessageBatchRequest
+	 *            Container for the necessary parameters to execute the
 	 *                                  DeleteMessageBatch service method on AmazonSQS.
+	 *
 	 * @return The response from the DeleteMessageBatch service method, as
 	 * returned by AmazonSQS.
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                               while attempting to make the request or handle the response.
 	 *                                               For example if a network connection is not available.
-	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                               either a problem with the data in the request, or a server
 	 *                                               side issue.
 	 */
@@ -772,18 +860,25 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param queueUrl The URL of the Amazon SQS queue to take action on.
-	 * @param entries  A list of receipt handles for the messages to be deleted.
+	 * @param queueUrl
+	 *            The URL of the Amazon SQS queue to take action on.
+	 * @param entries
+	 *            A list of receipt handles for the messages to be deleted.
+	 *
 	 * @return The response from the DeleteMessageBatch service method, as
 	 * returned by AmazonSQS.
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
 	 *                                               while attempting to make the request or handle the response.
 	 *                                               For example if a network connection is not available.
-	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
 	 *                                               either a problem with the data in the request, or a server
 	 *                                               side issue.
 	 */
@@ -812,14 +907,20 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * be received, but will be deleted within the next minute.
 	 * </p>
 	 *
-	 * @param purgeQueueRequest Container for the necessary parameters to execute the
+     * @param purgeQueueRequest
+     *            Container for the necessary parameters to execute the
 	 *                          PurgeQueue service method on AmazonSQS.
+     *
+     *
 	 * @throws PurgeQueueInProgressException
 	 * @throws QueueDoesNotExistException
-	 * @throws AmazonClientException         If any internal errors are encountered inside the client
+     *
+     * @throws AmazonClientException
+     *             If any internal errors are encountered inside the client
 	 *                                       while attempting to make the request or handle the response.
 	 *                                       For example if a network connection is not available.
-	 * @throws AmazonServiceException        If an error response is returned by AmazonSQS indicating
+     * @throws AmazonServiceException
+     *             If an error response is returned by AmazonSQS indicating
 	 *                                       either a problem with the data in the request, or a server
 	 *                                       side issue.
 	 */
@@ -1102,6 +1203,53 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		return counterOutputStream.getTotalSize();
 	}
 
+	/**
+	 * <p>
+	 * Changes the visibility timeout of multiple messages. This is a batch
+	 * version of ChangeMessageVisibility. The result of the action on each
+	 * message is reported individually in the response. You can send up to 10
+	 * ChangeMessageVisibility requests with each
+	 * <code>ChangeMessageVisibilityBatch</code> action.
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b>Because the batch request can result in a combination of
+	 * successful and unsuccessful actions, you should check for batch errors
+	 * even when the call returns an HTTP status code of 200.
+	 * </p>
+	 * <p>
+	 * <b>NOTE:</b>Some API actions take lists of parameters. These lists are
+	 * specified using the param.n notation. Values of n are integers starting
+	 * from 1. For example, a parameter list with two elements looks like this:
+	 * </p>
+	 * <p>
+	 * <code>&Attribute.1=this</code>
+	 * </p>
+	 * <p>
+	 * <code>&Attribute.2=that</code>
+	 * </p>
+	 *
+	 * @param queueUrl
+	 *            The URL of the Amazon SQS queue to take action on.
+	 * @param entries
+	 *            A list of receipt handles for the messages whose visibility is to be updated.
+	 *
+	 * @return The response from the ChangeMessageVisibilityBatch service
+	 *         method, as returned by AmazonSQS.
+	 *
+	 * @throws BatchEntryIdsNotDistinctException
+	 * @throws TooManyEntriesInBatchRequestException
+	 * @throws InvalidBatchEntryIdException
+	 * @throws EmptyBatchRequestException
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
+	 */
 	@Override
 	public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(String queueUrl,
 																																				 List<ChangeMessageVisibilityBatchRequestEntry> entries)
@@ -1109,6 +1257,52 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		return changeMessageVisibilityBatch(new ChangeMessageVisibilityBatchRequest(queueUrl, entries));
 	}
 
+	/**
+	 * <p>
+	 * Changes the visibility timeout of multiple messages. This is a batch
+	 * version of ChangeMessageVisibility. The result of the action on each
+	 * message is reported individually in the response. You can send up to 10
+	 * ChangeMessageVisibility requests with each
+	 * <code>ChangeMessageVisibilityBatch</code> action.
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b>Because the batch request can result in a combination of
+	 * successful and unsuccessful actions, you should check for batch errors
+	 * even when the call returns an HTTP status code of 200.
+	 * </p>
+	 * <p>
+	 * <b>NOTE:</b>Some API actions take lists of parameters. These lists are
+	 * specified using the param.n notation. Values of n are integers starting
+	 * from 1. For example, a parameter list with two elements looks like this:
+	 * </p>
+	 * <p>
+	 * <code>&Attribute.1=this</code>
+	 * </p>
+	 * <p>
+	 * <code>&Attribute.2=that</code>
+	 * </p>
+	 *
+	 * @param changeMessageVisibilityBatchRequest
+	 *            Container for the necessary parameters to execute the
+	 *            ChangeMessageVisibilityBatch service method on AmazonSQS.
+	 *
+	 * @return The response from the ChangeMessageVisibilityBatch service
+	 *         method, as returned by AmazonSQS.
+	 *
+	 * @throws BatchEntryIdsNotDistinctException
+	 * @throws TooManyEntriesInBatchRequestException
+	 * @throws InvalidBatchEntryIdException
+	 * @throws EmptyBatchRequestException
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
+	 */
 	@Override
 	public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(
 					ChangeMessageVisibilityBatchRequest changeMessageVisibilityBatchRequest) throws AmazonServiceException {
@@ -1132,12 +1326,135 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		return withOrigReceiptHandles;
 	}
 
+	/**
+	 * <p>
+	 * Changes the visibility timeout of a specified message in a queue to a new
+	 * value. The maximum allowed timeout value you can set the value to is 12
+	 * hours. This means you can't extend the timeout of a message in an
+	 * existing queue to more than a total visibility timeout of 12 hours. (For
+	 * more information visibility timeout, see <a href=
+	 * "http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html"
+	 * > Visibility Timeout </a> in the <i>Amazon SQS Developer Guide</i> .)
+	 * </p>
+	 * <p>
+	 * For example, let's say you have a message and its default message
+	 * visibility timeout is 30 minutes. You could call
+	 * <code>ChangeMessageVisiblity</code> with a value of two hours and the
+	 * effective timeout would be two hours and 30 minutes. When that time comes
+	 * near you could again extend the time out by calling
+	 * ChangeMessageVisiblity, but this time the maximum allowed timeout would
+	 * be 9 hours and 30 minutes.
+	 * </p>
+	 * <p>
+	 * <b>NOTE:</b> There is a 120,000 limit for the number of inflight messages
+	 * per queue. Messages are inflight after they have been received from the
+	 * queue by a consuming component, but have not yet been deleted from the
+	 * queue. If you reach the 120,000 limit, you will receive an OverLimit
+	 * error message from Amazon SQS. To help avoid reaching the limit, you
+	 * should delete the messages from the queue after they have been processed.
+	 * You can also increase the number of queues you use to process the
+	 * messages.
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b>If you attempt to set the VisibilityTimeout to an amount
+	 * more than the maximum time left, Amazon SQS returns an error. It will not
+	 * automatically recalculate and increase the timeout to the maximum time
+	 * remaining.
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b>Unlike with a queue, when you change the visibility
+	 * timeout for a specific message, that timeout value is applied immediately
+	 * but is not saved in memory for that message. If you don't delete a
+	 * message after it is received, the visibility timeout for the message the
+	 * next time it is received reverts to the original timeout value, not the
+	 * value you set with the ChangeMessageVisibility action.
+	 * </p>
+	 *
+	 * @param queueUrl
+	 *            The URL of the Amazon SQS queue to take action on.
+	 * @param receiptHandle
+	 *            The receipt handle associated with the message whose visibility will be updated.
+	 *
+	 *
+	 * @throws ReceiptHandleIsInvalidException
+	 * @throws MessageNotInflightException
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
+	 */
 	@Override
 	public void changeMessageVisibility(String queueUrl, String receiptHandle, Integer visibilityTimeout)
 					throws AmazonServiceException {
 		changeMessageVisibility(new ChangeMessageVisibilityRequest(queueUrl, receiptHandle, visibilityTimeout));
 	}
 
+	/**
+	 * <p>
+	 * Changes the visibility timeout of a specified message in a queue to a new
+	 * value. The maximum allowed timeout value you can set the value to is 12
+	 * hours. This means you can't extend the timeout of a message in an
+	 * existing queue to more than a total visibility timeout of 12 hours. (For
+	 * more information visibility timeout, see <a href=
+	 * "http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html"
+	 * > Visibility Timeout </a> in the <i>Amazon SQS Developer Guide</i> .)
+	 * </p>
+	 * <p>
+	 * For example, let's say you have a message and its default message
+	 * visibility timeout is 30 minutes. You could call
+	 * <code>ChangeMessageVisiblity</code> with a value of two hours and the
+	 * effective timeout would be two hours and 30 minutes. When that time comes
+	 * near you could again extend the time out by calling
+	 * ChangeMessageVisiblity, but this time the maximum allowed timeout would
+	 * be 9 hours and 30 minutes.
+	 * </p>
+	 * <p>
+	 * <b>NOTE:</b> There is a 120,000 limit for the number of inflight messages
+	 * per queue. Messages are inflight after they have been received from the
+	 * queue by a consuming component, but have not yet been deleted from the
+	 * queue. If you reach the 120,000 limit, you will receive an OverLimit
+	 * error message from Amazon SQS. To help avoid reaching the limit, you
+	 * should delete the messages from the queue after they have been processed.
+	 * You can also increase the number of queues you use to process the
+	 * messages.
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b>If you attempt to set the VisibilityTimeout to an amount
+	 * more than the maximum time left, Amazon SQS returns an error. It will not
+	 * automatically recalculate and increase the timeout to the maximum time
+	 * remaining.
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b>Unlike with a queue, when you change the visibility
+	 * timeout for a specific message, that timeout value is applied immediately
+	 * but is not saved in memory for that message. If you don't delete a
+	 * message after it is received, the visibility timeout for the message the
+	 * next time it is received reverts to the original timeout value, not the
+	 * value you set with the ChangeMessageVisibility action.
+	 * </p>
+	 *
+	 * @param changeMessageVisibilityRequest
+	 *            Container for the necessary parameters to execute the
+	 *            ChangeMessageVisibility service method on AmazonSQS.
+	 *
+	 *
+	 * @throws ReceiptHandleIsInvalidException
+	 * @throws MessageNotInflightException
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
+	 */
 	@Override
 	public void changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest)
 					throws AmazonServiceException {

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -22,6 +22,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,29 +35,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.BatchEntryIdsNotDistinctException;
-import com.amazonaws.services.sqs.model.BatchRequestTooLongException;
-import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
-import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
-import com.amazonaws.services.sqs.model.DeleteMessageBatchResult;
-import com.amazonaws.services.sqs.model.DeleteMessageRequest;
-import com.amazonaws.services.sqs.model.EmptyBatchRequestException;
-import com.amazonaws.services.sqs.model.InvalidBatchEntryIdException;
-import com.amazonaws.services.sqs.model.InvalidIdFormatException;
-import com.amazonaws.services.sqs.model.InvalidMessageContentsException;
-import com.amazonaws.services.sqs.model.Message;
-import com.amazonaws.services.sqs.model.MessageAttributeValue;
-import com.amazonaws.services.sqs.model.OverLimitException;
-import com.amazonaws.services.sqs.model.PurgeQueueRequest;
-import com.amazonaws.services.sqs.model.ReceiptHandleIsInvalidException;
-import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
-import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
-import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
-import com.amazonaws.services.sqs.model.SendMessageBatchResult;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
-import com.amazonaws.services.sqs.model.SendMessageResult;
-import com.amazonaws.services.sqs.model.TooManyEntriesInBatchRequestException;
+import com.amazonaws.services.sqs.model.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -139,10 +118,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * @param sendMessageRequest
 	 *            Container for the necessary parameters to execute the
 	 *            SendMessage service method on AmazonSQS.
-	 * 
+	 *
 	 * @return The response from the SendMessage service method, as returned by
 	 *         AmazonSQS.
-	 * 
+	 *
 	 * @throws InvalidMessageContentsException
 	 * @throws UnsupportedOperationException
 	 *
@@ -193,16 +172,16 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * characters not included in the list, your request will be rejected. #x9 |
 	 * #xA | #xD | [#x20 to #xD7FF] | [#xE000 to #xFFFD] | [#x10000 to #x10FFFF]
 	 * </p>
-	 * 
+	 *
 	 * @param queueUrl
 	 *            The URL of the Amazon SQS queue to take action on.
 	 * @param messageBody
 	 *            The message to send. For a list of allowed characters, see the
 	 *            preceding important note.
-	 * 
+	 *
 	 * @return The response from the SendMessage service method, as returned by
 	 *         AmazonSQS.
-	 * 
+	 *
 	 * @throws InvalidMessageContentsException
 	 * @throws UnsupportedOperationException
 	 *
@@ -244,7 +223,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * For each message returned, the response includes the following:
 	 * </p>
-	 * 
+	 *
 	 * <ul>
 	 * <li>
 	 * <p>
@@ -278,7 +257,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * MD5 digest of the message attributes.
 	 * </p>
 	 * </li>
-	 * 
+	 *
 	 * </ul>
 	 * <p>
 	 * The receipt handle is the identifier you must provide when deleting the
@@ -305,10 +284,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * @param receiveMessageRequest
 	 *            Container for the necessary parameters to execute the
 	 *            ReceiveMessage service method on AmazonSQS.
-	 * 
+	 *
 	 * @return The response from the ReceiveMessage service method, as returned
 	 *         by AmazonSQS.
-	 * 
+	 *
 	 * @throws OverLimitException
 	 *
 	 * @throws AmazonClientException
@@ -396,7 +375,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * For each message returned, the response includes the following:
 	 * </p>
-	 * 
+	 *
 	 * <ul>
 	 * <li>
 	 * <p>
@@ -430,7 +409,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * MD5 digest of the message attributes.
 	 * </p>
 	 * </li>
-	 * 
+	 *
 	 * </ul>
 	 * <p>
 	 * The receipt handle is the identifier you must provide when deleting the
@@ -453,13 +432,13 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * writing code that calls this action, we recommend that you structure your
 	 * code so that it can handle new attributes gracefully.
 	 * </p>
-	 * 
+	 *
 	 * @param queueUrl
 	 *            The URL of the Amazon SQS queue to take action on.
-	 * 
+	 *
 	 * @return The response from the ReceiveMessage service method, as returned
 	 *         by AmazonSQS.
-	 * 
+	 *
 	 * @throws OverLimitException
 	 *
 	 * @throws AmazonClientException
@@ -508,8 +487,8 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * @param deleteMessageRequest
 	 *            Container for the necessary parameters to execute the
 	 *            DeleteMessage service method on AmazonSQS.
-	 * 
-	 * 
+	 *
+	 *
 	 * @throws ReceiptHandleIsInvalidException
 	 * @throws InvalidIdFormatException
 	 *
@@ -575,15 +554,15 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * system to be idempotent so that receiving a particular message more than
 	 * once is not a problem.
 	 * </p>
-	 * 
+	 *
 	 * @param queueUrl
 	 *            The URL of the Amazon SQS queue to take action on.
 	 * @param receiptHandle
 	 *            The receipt handle associated with the message to delete.
-	 * 
+	 *
 	 * @return The response from the DeleteMessage service method, as returned
 	 *         by AmazonSQS.
-	 * 
+	 *
 	 * @throws ReceiptHandleIsInvalidException
 	 * @throws InvalidIdFormatException
 	 *
@@ -641,10 +620,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * @param sendMessageBatchRequest
 	 *            Container for the necessary parameters to execute the
 	 *            SendMessageBatch service method on AmazonSQS.
-	 * 
+	 *
 	 * @return The response from the SendMessageBatch service method, as
 	 *         returned by AmazonSQS.
-	 * 
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws BatchRequestTooLongException
@@ -723,15 +702,15 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * <code>&Attribute.2=that</code>
 	 * </p>
-	 * 
+	 *
 	 * @param queueUrl
 	 *            The URL of the Amazon SQS queue to take action on.
 	 * @param entries
 	 *            A list of <a>SendMessageBatchRequestEntry</a> items.
-	 * 
+	 *
 	 * @return The response from the SendMessageBatch service method, as
 	 *         returned by AmazonSQS.
-	 * 
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws BatchRequestTooLongException
@@ -780,10 +759,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * @param deleteMessageBatchRequest
 	 *            Container for the necessary parameters to execute the
 	 *            DeleteMessageBatch service method on AmazonSQS.
-	 * 
+	 *
 	 * @return The response from the DeleteMessageBatch service method, as
 	 *         returned by AmazonSQS.
-	 * 
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws InvalidBatchEntryIdException
@@ -848,15 +827,15 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * <code>&Attribute.2=that</code>
 	 * </p>
-	 * 
+	 *
 	 * @param queueUrl
 	 *            The URL of the Amazon SQS queue to take action on.
 	 * @param entries
 	 *            A list of receipt handles for the messages to be deleted.
-	 * 
+	 *
 	 * @return The response from the DeleteMessageBatch service method, as
 	 *         returned by AmazonSQS.
-	 * 
+	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws InvalidBatchEntryIdException
@@ -1194,4 +1173,52 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		return counterOutputStream.getTotalSize();
 	}
 
+	@Override
+	public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(String queueUrl,
+																																				 List<ChangeMessageVisibilityBatchRequestEntry> entries)
+					throws AmazonServiceException {
+		return super.changeMessageVisibilityBatch(queueUrl, removeEmbedS3PointerFromVisibilityBatchEntries(entries));
+	}
+
+	@Override
+	public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(
+					ChangeMessageVisibilityBatchRequest changeMessageVisibilityBatchRequest) throws AmazonServiceException {
+		changeMessageVisibilityBatchRequest = new ChangeMessageVisibilityBatchRequest(changeMessageVisibilityBatchRequest.getQueueUrl(),
+																																									removeEmbedS3PointerFromVisibilityBatchEntries(
+																																													changeMessageVisibilityBatchRequest.getEntries()));
+		return super.changeMessageVisibilityBatch(changeMessageVisibilityBatchRequest);
+	}
+
+	private List<ChangeMessageVisibilityBatchRequestEntry> removeEmbedS3PointerFromVisibilityBatchEntries(
+					List<ChangeMessageVisibilityBatchRequestEntry> entries) {
+		List<ChangeMessageVisibilityBatchRequestEntry> withOrigReceiptHandles = new ArrayList<>();
+		for (ChangeMessageVisibilityBatchRequestEntry entry : entries) {
+			if (isS3ReceiptHandle(entry.getReceiptHandle())) {
+				withOrigReceiptHandles.add(new ChangeMessageVisibilityBatchRequestEntry(entry.getId(),
+																																								getOrigReceiptHandle(entry.getReceiptHandle())));
+			} else {
+				withOrigReceiptHandles.add(entry);
+			}
+		}
+		return withOrigReceiptHandles;
+	}
+
+	@Override
+	public void changeMessageVisibility(String queueUrl, String receiptHandle, Integer visibilityTimeout)
+					throws AmazonServiceException {
+		super.changeMessageVisibility(queueUrl,
+																	isS3ReceiptHandle(receiptHandle) ? getOrigReceiptHandle(receiptHandle) : receiptHandle,
+																	visibilityTimeout);
+	}
+
+	@Override
+	public void changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest)
+					throws AmazonServiceException {
+		if (isS3ReceiptHandle(changeMessageVisibilityRequest.getReceiptHandle())) {
+			changeMessageVisibilityRequest = new ChangeMessageVisibilityRequest(changeMessageVisibilityRequest.getQueueUrl(),
+																																					getOrigReceiptHandle(changeMessageVisibilityRequest.getReceiptHandle()),
+																																					changeMessageVisibilityRequest.getVisibilityTimeout());
+		}
+		super.changeMessageVisibility(changeMessageVisibilityRequest);
+	}
 }

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -209,22 +209,22 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *            The URL of the Amazon SQS queue to take action on.
 	 * @param messageBody
 	 *            The message to send. For a list of allowed characters, see the
-	 *                    preceding important note.
+	 *            preceding important note.
 	 *
 	 * @return The response from the SendMessage service method, as returned by
-	 * AmazonSQS.
+	 *         AmazonSQS.
 	 *
 	 * @throws InvalidMessageContentsException
 	 * @throws UnsupportedOperationException
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                         while attempting to make the request or handle the response.
-	 *                                         For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                         either a problem with the data in the request, or a server
-	 *                                         side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public SendMessageResult sendMessage(String queueUrl, String messageBody) {
 		SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody);
@@ -315,21 +315,21 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @param receiveMessageRequest
 	 *            Container for the necessary parameters to execute the
-	 *                              ReceiveMessage service method on AmazonSQS.
+	 *            ReceiveMessage service method on AmazonSQS.
 	 *
 	 * @return The response from the ReceiveMessage service method, as returned
-	 * by AmazonSQS.
+	 *         by AmazonSQS.
 	 *
 	 * @throws OverLimitException
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                while attempting to make the request or handle the response.
-	 *                                For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                either a problem with the data in the request, or a server
-	 *                                side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public ReceiveMessageResult receiveMessage(ReceiveMessageRequest receiveMessageRequest) {
 
@@ -470,18 +470,18 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *            The URL of the Amazon SQS queue to take action on.
 	 *
 	 * @return The response from the ReceiveMessage service method, as returned
-	 * by AmazonSQS.
+	 *         by AmazonSQS.
 	 *
 	 * @throws OverLimitException
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                while attempting to make the request or handle the response.
-	 *                                For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                either a problem with the data in the request, or a server
-	 *                                side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public ReceiveMessageResult receiveMessage(String queueUrl) {
 		ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
@@ -519,7 +519,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @param deleteMessageRequest
 	 *            Container for the necessary parameters to execute the
-	 *                             DeleteMessage service method on AmazonSQS.
+	 *            DeleteMessage service method on AmazonSQS.
 	 *
 	 *
 	 * @throws ReceiptHandleIsInvalidException
@@ -527,12 +527,12 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                         while attempting to make the request or handle the response.
-	 *                                         For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                         either a problem with the data in the request, or a server
-	 *                                         side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public void deleteMessage(DeleteMessageRequest deleteMessageRequest) {
 
@@ -594,19 +594,19 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *            The receipt handle associated with the message to delete.
 	 *
 	 * @return The response from the DeleteMessage service method, as returned
-	 * by AmazonSQS.
+	 *         by AmazonSQS.
 	 *
 	 * @throws ReceiptHandleIsInvalidException
 	 * @throws InvalidIdFormatException
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                         while attempting to make the request or handle the response.
-	 *                                         For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                         either a problem with the data in the request, or a server
-	 *                                         side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public void deleteMessage(String queueUrl, String receiptHandle) {
 		DeleteMessageRequest deleteMessageRequest = new DeleteMessageRequest(queueUrl, receiptHandle);
@@ -652,10 +652,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @param sendMessageBatchRequest
 	 *            Container for the necessary parameters to execute the
-	 *                                SendMessageBatch service method on AmazonSQS.
+	 *            SendMessageBatch service method on AmazonSQS.
 	 *
 	 * @return The response from the SendMessageBatch service method, as
-	 * returned by AmazonSQS.
+	 *         returned by AmazonSQS.
 	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
@@ -666,12 +666,12 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                               while attempting to make the request or handle the response.
-	 *                                               For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                               either a problem with the data in the request, or a server
-	 *                                               side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public SendMessageBatchResult sendMessageBatch(SendMessageBatchRequest sendMessageBatchRequest) {
 
@@ -742,7 +742,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *            A list of <a>SendMessageBatchRequestEntry</a> items.
 	 *
 	 * @return The response from the SendMessageBatch service method, as
-	 * returned by AmazonSQS.
+	 *         returned by AmazonSQS.
 	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
@@ -753,12 +753,12 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                               while attempting to make the request or handle the response.
-	 *                                               For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                               either a problem with the data in the request, or a server
-	 *                                               side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public SendMessageBatchResult sendMessageBatch(String queueUrl, List<SendMessageBatchRequestEntry> entries) {
 		SendMessageBatchRequest sendMessageBatchRequest = new SendMessageBatchRequest(queueUrl, entries);
@@ -791,10 +791,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @param deleteMessageBatchRequest
 	 *            Container for the necessary parameters to execute the
-	 *                                  DeleteMessageBatch service method on AmazonSQS.
+	 *            DeleteMessageBatch service method on AmazonSQS.
 	 *
 	 * @return The response from the DeleteMessageBatch service method, as
-	 * returned by AmazonSQS.
+	 *         returned by AmazonSQS.
 	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
@@ -803,12 +803,12 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                               while attempting to make the request or handle the response.
-	 *                                               For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                               either a problem with the data in the request, or a server
-	 *                                               side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public DeleteMessageBatchResult deleteMessageBatch(DeleteMessageBatchRequest deleteMessageBatchRequest) {
 
@@ -866,7 +866,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *            A list of receipt handles for the messages to be deleted.
 	 *
 	 * @return The response from the DeleteMessageBatch service method, as
-	 * returned by AmazonSQS.
+	 *         returned by AmazonSQS.
 	 *
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
@@ -875,12 +875,12 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 *
 	 * @throws AmazonClientException
 	 *             If any internal errors are encountered inside the client
-	 *                                               while attempting to make the request or handle the response.
-	 *                                               For example if a network connection is not available.
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
 	 * @throws AmazonServiceException
 	 *             If an error response is returned by AmazonSQS indicating
-	 *                                               either a problem with the data in the request, or a server
-	 *                                               side issue.
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public DeleteMessageBatchResult deleteMessageBatch(String queueUrl, List<DeleteMessageBatchRequestEntry> entries) {
 		DeleteMessageBatchRequest deleteMessageBatchRequest = new DeleteMessageBatchRequest(queueUrl, entries);
@@ -907,22 +907,22 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * be received, but will be deleted within the next minute.
 	 * </p>
 	 *
-     * @param purgeQueueRequest
-     *            Container for the necessary parameters to execute the
-	 *                          PurgeQueue service method on AmazonSQS.
-     *
-     *
+	 * @param purgeQueueRequest
+	 *            Container for the necessary parameters to execute the
+	 *            PurgeQueue service method on AmazonSQS.
+	 *
+	 *
 	 * @throws PurgeQueueInProgressException
 	 * @throws QueueDoesNotExistException
-     *
-     * @throws AmazonClientException
-     *             If any internal errors are encountered inside the client
-	 *                                       while attempting to make the request or handle the response.
-	 *                                       For example if a network connection is not available.
-     * @throws AmazonServiceException
-     *             If an error response is returned by AmazonSQS indicating
-	 *                                       either a problem with the data in the request, or a server
-	 *                                       side issue.
+	 *
+	 * @throws AmazonClientException
+	 *             If any internal errors are encountered inside the client
+	 *             while attempting to make the request or handle the response.
+	 *             For example if a network connection is not available.
+	 * @throws AmazonServiceException
+	 *             If an error response is returned by AmazonSQS indicating
+	 *             either a problem with the data in the request, or a server
+	 *             side issue.
 	 */
 	public void purgeQueue(PurgeQueueRequest purgeQueueRequest) throws AmazonServiceException, AmazonClientException {
 		LOG.warn("Calling purgeQueue deletes SQS messages without deleting their payload from S3.");

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -45,12 +45,12 @@ import org.apache.commons.logging.LogFactory;
  * Amazon SQS Extended Client extends the functionality of Amazon SQS client.
  * All service calls made using this client are blocking, and will not return
  * until the service call completes.
- *
+ * <p/>
  * <p>
  * The Amazon SQS extended client enables sending and receiving large messages
  * via Amazon S3. You can use this library to:
  * </p>
- *
+ * <p/>
  * <ul>
  * <li>Specify whether messages are always stored in Amazon S3 or only when a
  * message size exceeds 256 KB.</li>
@@ -69,13 +69,12 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * Constructs a new Amazon SQS extended client to invoke service methods on
 	 * Amazon SQS with extended functionality using the specified Amazon SQS
 	 * client object.
-	 *
-	 * <p>
+	 * <p/>
+	 * <p/>
 	 * All service calls made using this new client object are blocking, and
 	 * will not return until the service call completes.
 	 *
-	 * @param sqsClient
-	 *            The Amazon SQS client to use to connect to Amazon SQS.
+	 * @param sqsClient The Amazon SQS client to use to connect to Amazon SQS.
 	 */
 	public AmazonSQSExtendedClient(AmazonSQS sqsClient) {
 		this(sqsClient, new ExtendedClientConfiguration());
@@ -85,16 +84,14 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * Constructs a new Amazon SQS extended client to invoke service methods on
 	 * Amazon SQS with extended functionality using the specified Amazon SQS
 	 * client object.
-	 *
-	 * <p>
+	 * <p/>
+	 * <p/>
 	 * All service calls made using this new client object are blocking, and
 	 * will not return until the service call completes.
 	 *
-	 * @param sqsClient
-	 *            The Amazon SQS client to use to connect to Amazon SQS.
-	 * @param extendedClientConfig
-	 *            The extended client configuration options controlling the
-	 *            functionality of this client.
+	 * @param sqsClient            The Amazon SQS client to use to connect to Amazon SQS.
+	 * @param extendedClientConfig The extended client configuration options controlling the
+	 *                             functionality of this client.
 	 */
 	public AmazonSQSExtendedClient(AmazonSQS sqsClient, ExtendedClientConfiguration extendedClientConfig) {
 		super(sqsClient);
@@ -113,27 +110,21 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * characters not included in the list, your request will be rejected. #x9 |
 	 * #xA | #xD | [#x20 to #xD7FF] | [#xE000 to #xFFFD] | [#x10000 to #x10FFFF]
 	 * </p>
-	 *
+	 * <p/>
 	 * <b>IMPORTANT:</b> The input object may be modified by the method. </p>
 	 *
-	 * @param sendMessageRequest
-	 *            Container for the necessary parameters to execute the
-	 *            SendMessage service method on AmazonSQS.
-	 *
+	 * @param sendMessageRequest Container for the necessary parameters to execute the
+	 *                           SendMessage service method on AmazonSQS.
 	 * @return The response from the SendMessage service method, as returned by
-	 *         AmazonSQS.
-	 *
+	 * AmazonSQS.
 	 * @throws InvalidMessageContentsException
 	 * @throws UnsupportedOperationException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *                                         while attempting to make the request or handle the response.
+	 *                                         For example if a network connection is not available.
+	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 *                                         either a problem with the data in the request, or a server
+	 *                                         side issue.
 	 */
 	public SendMessageResult sendMessage(SendMessageRequest sendMessageRequest) {
 
@@ -174,26 +165,19 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * #xA | #xD | [#x20 to #xD7FF] | [#xE000 to #xFFFD] | [#x10000 to #x10FFFF]
 	 * </p>
 	 *
-	 * @param queueUrl
-	 *            The URL of the Amazon SQS queue to take action on.
-	 * @param messageBody
-	 *            The message to send. For a list of allowed characters, see the
-	 *            preceding important note.
-	 *
+	 * @param queueUrl    The URL of the Amazon SQS queue to take action on.
+	 * @param messageBody The message to send. For a list of allowed characters, see the
+	 *                    preceding important note.
 	 * @return The response from the SendMessage service method, as returned by
-	 *         AmazonSQS.
-	 *
+	 * AmazonSQS.
 	 * @throws InvalidMessageContentsException
 	 * @throws UnsupportedOperationException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *                                         while attempting to make the request or handle the response.
+	 *                                         For example if a network connection is not available.
+	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 *                                         either a problem with the data in the request, or a server
+	 *                                         side issue.
 	 */
 	public SendMessageResult sendMessage(String queueUrl, String messageBody) {
 		SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody);
@@ -224,7 +208,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * For each message returned, the response includes the following:
 	 * </p>
-	 *
+	 * <p/>
 	 * <ul>
 	 * <li>
 	 * <p>
@@ -258,7 +242,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * MD5 digest of the message attributes.
 	 * </p>
 	 * </li>
-	 *
+	 * <p/>
 	 * </ul>
 	 * <p>
 	 * The receipt handle is the identifier you must provide when deleting the
@@ -282,23 +266,17 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * code so that it can handle new attributes gracefully.
 	 * </p>
 	 *
-	 * @param receiveMessageRequest
-	 *            Container for the necessary parameters to execute the
-	 *            ReceiveMessage service method on AmazonSQS.
-	 *
+	 * @param receiveMessageRequest Container for the necessary parameters to execute the
+	 *                              ReceiveMessage service method on AmazonSQS.
 	 * @return The response from the ReceiveMessage service method, as returned
-	 *         by AmazonSQS.
-	 *
+	 * by AmazonSQS.
 	 * @throws OverLimitException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException  If any internal errors are encountered inside the client
+	 *                                while attempting to make the request or handle the response.
+	 *                                For example if a network connection is not available.
+	 * @throws AmazonServiceException If an error response is returned by AmazonSQS indicating
+	 *                                either a problem with the data in the request, or a server
+	 *                                side issue.
 	 */
 	public ReceiveMessageResult receiveMessage(ReceiveMessageRequest receiveMessageRequest) {
 
@@ -322,8 +300,8 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		for (Message message : messages) {
 
 			// for each received message check if they are stored in S3.
-			MessageAttributeValue largePayloadAttributeValue = message.getMessageAttributes().get(
-					SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
+			MessageAttributeValue largePayloadAttributeValue = message.getMessageAttributes()
+																																.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
 			if (largePayloadAttributeValue != null) {
 				String messageBody = message.getBody();
 
@@ -343,8 +321,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 				message.getMessageAttributes().remove(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
 
 				// Embed s3 object pointer in the receipt handle.
-				String modifiedReceiptHandle = embedS3PointerInReceiptHandle(message.getReceiptHandle(),
-						s3MsgBucketName, s3MsgKey);
+				String modifiedReceiptHandle = embedS3PointerInReceiptHandle(message.getReceiptHandle(), s3MsgBucketName, s3MsgKey);
 
 				message.setReceiptHandle(modifiedReceiptHandle);
 			}
@@ -376,7 +353,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <p>
 	 * For each message returned, the response includes the following:
 	 * </p>
-	 *
+	 * <p/>
 	 * <ul>
 	 * <li>
 	 * <p>
@@ -410,7 +387,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * MD5 digest of the message attributes.
 	 * </p>
 	 * </li>
-	 *
+	 * <p/>
 	 * </ul>
 	 * <p>
 	 * The receipt handle is the identifier you must provide when deleting the
@@ -434,22 +411,16 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * code so that it can handle new attributes gracefully.
 	 * </p>
 	 *
-	 * @param queueUrl
-	 *            The URL of the Amazon SQS queue to take action on.
-	 *
+	 * @param queueUrl The URL of the Amazon SQS queue to take action on.
 	 * @return The response from the ReceiveMessage service method, as returned
-	 *         by AmazonSQS.
-	 *
+	 * by AmazonSQS.
 	 * @throws OverLimitException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException  If any internal errors are encountered inside the client
+	 *                                while attempting to make the request or handle the response.
+	 *                                For example if a network connection is not available.
+	 * @throws AmazonServiceException If an error response is returned by AmazonSQS indicating
+	 *                                either a problem with the data in the request, or a server
+	 *                                side issue.
 	 */
 	public ReceiveMessageResult receiveMessage(String queueUrl) {
 		ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
@@ -485,22 +456,16 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * once is not a problem.
 	 * </p>
 	 *
-	 * @param deleteMessageRequest
-	 *            Container for the necessary parameters to execute the
-	 *            DeleteMessage service method on AmazonSQS.
-	 *
-	 *
+	 * @param deleteMessageRequest Container for the necessary parameters to execute the
+	 *                             DeleteMessage service method on AmazonSQS.
 	 * @throws ReceiptHandleIsInvalidException
 	 * @throws InvalidIdFormatException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *                                         while attempting to make the request or handle the response.
+	 *                                         For example if a network connection is not available.
+	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 *                                         either a problem with the data in the request, or a server
+	 *                                         side issue.
 	 */
 	public void deleteMessage(DeleteMessageRequest deleteMessageRequest) {
 
@@ -556,25 +521,18 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * once is not a problem.
 	 * </p>
 	 *
-	 * @param queueUrl
-	 *            The URL of the Amazon SQS queue to take action on.
-	 * @param receiptHandle
-	 *            The receipt handle associated with the message to delete.
-	 *
+	 * @param queueUrl      The URL of the Amazon SQS queue to take action on.
+	 * @param receiptHandle The receipt handle associated with the message to delete.
 	 * @return The response from the DeleteMessage service method, as returned
-	 *         by AmazonSQS.
-	 *
+	 * by AmazonSQS.
 	 * @throws ReceiptHandleIsInvalidException
 	 * @throws InvalidIdFormatException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException           If any internal errors are encountered inside the client
+	 *                                         while attempting to make the request or handle the response.
+	 *                                         For example if a network connection is not available.
+	 * @throws AmazonServiceException          If an error response is returned by AmazonSQS indicating
+	 *                                         either a problem with the data in the request, or a server
+	 *                                         side issue.
 	 */
 	public void deleteMessage(String queueUrl, String receiptHandle) {
 		DeleteMessageRequest deleteMessageRequest = new DeleteMessageRequest(queueUrl, receiptHandle);
@@ -618,28 +576,22 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param sendMessageBatchRequest
-	 *            Container for the necessary parameters to execute the
-	 *            SendMessageBatch service method on AmazonSQS.
-	 *
+	 * @param sendMessageBatchRequest Container for the necessary parameters to execute the
+	 *                                SendMessageBatch service method on AmazonSQS.
 	 * @return The response from the SendMessageBatch service method, as
-	 *         returned by AmazonSQS.
-	 *
+	 * returned by AmazonSQS.
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws BatchRequestTooLongException
 	 * @throws UnsupportedOperationException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *                                               while attempting to make the request or handle the response.
+	 *                                               For example if a network connection is not available.
+	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 *                                               either a problem with the data in the request, or a server
+	 *                                               side issue.
 	 */
 	public SendMessageBatchResult sendMessageBatch(SendMessageBatchRequest sendMessageBatchRequest) {
 
@@ -704,29 +656,22 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param queueUrl
-	 *            The URL of the Amazon SQS queue to take action on.
-	 * @param entries
-	 *            A list of <a>SendMessageBatchRequestEntry</a> items.
-	 *
+	 * @param queueUrl The URL of the Amazon SQS queue to take action on.
+	 * @param entries  A list of <a>SendMessageBatchRequestEntry</a> items.
 	 * @return The response from the SendMessageBatch service method, as
-	 *         returned by AmazonSQS.
-	 *
+	 * returned by AmazonSQS.
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws BatchRequestTooLongException
 	 * @throws UnsupportedOperationException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *                                               while attempting to make the request or handle the response.
+	 *                                               For example if a network connection is not available.
+	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 *                                               either a problem with the data in the request, or a server
+	 *                                               side issue.
 	 */
 	public SendMessageBatchResult sendMessageBatch(String queueUrl, List<SendMessageBatchRequestEntry> entries) {
 		SendMessageBatchRequest sendMessageBatchRequest = new SendMessageBatchRequest(queueUrl, entries);
@@ -757,26 +702,20 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param deleteMessageBatchRequest
-	 *            Container for the necessary parameters to execute the
-	 *            DeleteMessageBatch service method on AmazonSQS.
-	 *
+	 * @param deleteMessageBatchRequest Container for the necessary parameters to execute the
+	 *                                  DeleteMessageBatch service method on AmazonSQS.
 	 * @return The response from the DeleteMessageBatch service method, as
-	 *         returned by AmazonSQS.
-	 *
+	 * returned by AmazonSQS.
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *                                               while attempting to make the request or handle the response.
+	 *                                               For example if a network connection is not available.
+	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 *                                               either a problem with the data in the request, or a server
+	 *                                               side issue.
 	 */
 	public DeleteMessageBatchResult deleteMessageBatch(DeleteMessageBatchRequest deleteMessageBatchRequest) {
 
@@ -786,8 +725,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 			throw new AmazonClientException(errorMessage);
 		}
 
-		deleteMessageBatchRequest.getRequestClientOptions().appendUserAgent(
-				SQSExtendedClientConstants.USER_AGENT_HEADER);
+		deleteMessageBatchRequest.getRequestClientOptions().appendUserAgent(SQSExtendedClientConstants.USER_AGENT_HEADER);
 
 		if (!clientConfiguration.isLargePayloadSupportEnabled()) {
 			return super.deleteMessageBatch(deleteMessageBatchRequest);
@@ -829,70 +767,57 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	 * <code>&Attribute.2=that</code>
 	 * </p>
 	 *
-	 * @param queueUrl
-	 *            The URL of the Amazon SQS queue to take action on.
-	 * @param entries
-	 *            A list of receipt handles for the messages to be deleted.
-	 *
+	 * @param queueUrl The URL of the Amazon SQS queue to take action on.
+	 * @param entries  A list of receipt handles for the messages to be deleted.
 	 * @return The response from the DeleteMessageBatch service method, as
-	 *         returned by AmazonSQS.
-	 *
+	 * returned by AmazonSQS.
 	 * @throws BatchEntryIdsNotDistinctException
 	 * @throws TooManyEntriesInBatchRequestException
 	 * @throws InvalidBatchEntryIdException
 	 * @throws EmptyBatchRequestException
-	 *
-	 * @throws AmazonClientException
-	 *             If any internal errors are encountered inside the client
-	 *             while attempting to make the request or handle the response.
-	 *             For example if a network connection is not available.
-	 * @throws AmazonServiceException
-	 *             If an error response is returned by AmazonSQS indicating
-	 *             either a problem with the data in the request, or a server
-	 *             side issue.
+	 * @throws AmazonClientException                 If any internal errors are encountered inside the client
+	 *                                               while attempting to make the request or handle the response.
+	 *                                               For example if a network connection is not available.
+	 * @throws AmazonServiceException                If an error response is returned by AmazonSQS indicating
+	 *                                               either a problem with the data in the request, or a server
+	 *                                               side issue.
 	 */
 	public DeleteMessageBatchResult deleteMessageBatch(String queueUrl, List<DeleteMessageBatchRequestEntry> entries) {
 		DeleteMessageBatchRequest deleteMessageBatchRequest = new DeleteMessageBatchRequest(queueUrl, entries);
 		return deleteMessageBatch(deleteMessageBatchRequest);
 	}
 
-    /**
-     * <p>
-     * Deletes the messages in a queue specified by the <b>queue URL</b> .
-     * </p>
-     * <p>
-     * <b>IMPORTANT:</b>When you use the PurgeQueue API, the deleted messages in
-     * the queue cannot be retrieved.
-     * </p>
-     * <p>
-     * <b>IMPORTANT:</b> This does not delete the message payloads from Amazon S3.
-     * </p>
-     * <p>
-     * When you purge a queue, the message deletion process takes up to 60
-     * seconds. All messages sent to the queue before calling
-     * <code>PurgeQueue</code> will be deleted; messages sent to the queue while
-     * it is being purged may be deleted. While the queue is being purged,
-     * messages sent to the queue before <code>PurgeQueue</code> was called may
-     * be received, but will be deleted within the next minute.
-     * </p>
-     *
-     * @param purgeQueueRequest
-     *            Container for the necessary parameters to execute the
-     *            PurgeQueue service method on AmazonSQS.
-     *
-     *
-     * @throws PurgeQueueInProgressException
-     * @throws QueueDoesNotExistException
-     *
-     * @throws AmazonClientException
-     *             If any internal errors are encountered inside the client
-     *             while attempting to make the request or handle the response.
-     *             For example if a network connection is not available.
-     * @throws AmazonServiceException
-     *             If an error response is returned by AmazonSQS indicating
-     *             either a problem with the data in the request, or a server
-     *             side issue.
-     */
+	/**
+	 * <p>
+	 * Deletes the messages in a queue specified by the <b>queue URL</b> .
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b>When you use the PurgeQueue API, the deleted messages in
+	 * the queue cannot be retrieved.
+	 * </p>
+	 * <p>
+	 * <b>IMPORTANT:</b> This does not delete the message payloads from Amazon S3.
+	 * </p>
+	 * <p>
+	 * When you purge a queue, the message deletion process takes up to 60
+	 * seconds. All messages sent to the queue before calling
+	 * <code>PurgeQueue</code> will be deleted; messages sent to the queue while
+	 * it is being purged may be deleted. While the queue is being purged,
+	 * messages sent to the queue before <code>PurgeQueue</code> was called may
+	 * be received, but will be deleted within the next minute.
+	 * </p>
+	 *
+	 * @param purgeQueueRequest Container for the necessary parameters to execute the
+	 *                          PurgeQueue service method on AmazonSQS.
+	 * @throws PurgeQueueInProgressException
+	 * @throws QueueDoesNotExistException
+	 * @throws AmazonClientException         If any internal errors are encountered inside the client
+	 *                                       while attempting to make the request or handle the response.
+	 *                                       For example if a network connection is not available.
+	 * @throws AmazonServiceException        If an error response is returned by AmazonSQS indicating
+	 *                                       either a problem with the data in the request, or a server
+	 *                                       side issue.
+	 */
 	public void purgeQueue(PurgeQueueRequest purgeQueueRequest) throws AmazonServiceException, AmazonClientException {
 		LOG.warn("Calling purgeQueue deletes SQS messages without deleting their payload from S3.");
 
@@ -908,8 +833,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	}
 
 	private void deleteMessagePayloadFromS3(String receiptHandle) {
-		String s3MsgBucketName = getFromReceiptHandleByMarker(receiptHandle,
-				SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER);
+		String s3MsgBucketName = getFromReceiptHandleByMarker(receiptHandle, SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER);
 		String s3MsgKey = getFromReceiptHandleByMarker(receiptHandle, SQSExtendedClientConstants.S3_KEY_MARKER);
 		try {
 			clientConfiguration.getAmazonS3Client().deleteObject(new DeleteObjectRequest(s3MsgBucketName, s3MsgKey));
@@ -928,9 +852,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	private void checkMessageAttributes(Map<String, MessageAttributeValue> messageAttributes) {
 		int msgAttributesSize = getMsgAttributesSize(messageAttributes);
 		if (msgAttributesSize > clientConfiguration.getMessageSizeThreshold()) {
-			String errorMessage = "Total size of Message attributes is " + msgAttributesSize
-					+ " bytes which is larger than the threshold of " + clientConfiguration.getMessageSizeThreshold()
-					+ " Bytes. Consider including the payload in the message body instead of message attributes.";
+			String errorMessage =
+							"Total size of Message attributes is " + msgAttributesSize + " bytes which is larger than the threshold of "
+							+ clientConfiguration.getMessageSizeThreshold()
+							+ " Bytes. Consider including the payload in the message body instead of message attributes.";
 			LOG.error(errorMessage);
 			throw new AmazonClientException(errorMessage);
 		}
@@ -938,17 +863,16 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		int messageAttributesNum = messageAttributes.size();
 		if (messageAttributesNum > SQSExtendedClientConstants.MAX_ALLOWED_ATTRIBUTES) {
 			String errorMessage = "Number of message attributes [" + messageAttributesNum
-					+ "] exceeds the maximum allowed for large-payload messages ["
-					+ SQSExtendedClientConstants.MAX_ALLOWED_ATTRIBUTES + "].";
+														+ "] exceeds the maximum allowed for large-payload messages ["
+														+ SQSExtendedClientConstants.MAX_ALLOWED_ATTRIBUTES + "].";
 			LOG.error(errorMessage);
 			throw new AmazonClientException(errorMessage);
 		}
 
-		MessageAttributeValue largePayloadAttributeValue = messageAttributes
-				.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
+		MessageAttributeValue largePayloadAttributeValue = messageAttributes.get(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME);
 		if (largePayloadAttributeValue != null) {
 			String errorMessage = "Message attribute name " + SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME
-					+ " is reserved for use by SQS extended client.";
+														+ " is reserved for use by SQS extended client.";
 			LOG.error(errorMessage);
 			throw new AmazonClientException(errorMessage);
 		}
@@ -956,9 +880,9 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	}
 
 	private String embedS3PointerInReceiptHandle(String receiptHandle, String s3MsgBucketName, String s3MsgKey) {
-		String modifiedReceiptHandle = SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER + s3MsgBucketName
-				+ SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER + SQSExtendedClientConstants.S3_KEY_MARKER
-				+ s3MsgKey + SQSExtendedClientConstants.S3_KEY_MARKER + receiptHandle;
+		String modifiedReceiptHandle =
+						SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER + s3MsgBucketName + SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER
+						+ SQSExtendedClientConstants.S3_KEY_MARKER + s3MsgKey + SQSExtendedClientConstants.S3_KEY_MARKER + receiptHandle;
 		return modifiedReceiptHandle;
 	}
 
@@ -978,7 +902,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 
 	private String getOrigReceiptHandle(String receiptHandle) {
 		int secondOccurence = receiptHandle.indexOf(SQSExtendedClientConstants.S3_KEY_MARKER,
-				receiptHandle.indexOf(SQSExtendedClientConstants.S3_KEY_MARKER) + 1);
+																								receiptHandle.indexOf(SQSExtendedClientConstants.S3_KEY_MARKER) + 1);
 		return receiptHandle.substring(secondOccurence + SQSExtendedClientConstants.S3_KEY_MARKER.length());
 	}
 
@@ -989,8 +913,8 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	}
 
 	private boolean isS3ReceiptHandle(String receiptHandle) {
-		return receiptHandle.contains(SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER)
-				&& receiptHandle.contains(SQSExtendedClientConstants.S3_KEY_MARKER);
+		return receiptHandle.contains(SQSExtendedClientConstants.S3_BUCKET_NAME_MARKER) && receiptHandle.contains(
+						SQSExtendedClientConstants.S3_KEY_MARKER);
 	}
 
 	private String getTextFromS3(String s3BucketName, String s3Key) {
@@ -1080,8 +1004,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		// Store the message content in S3.
 		storeTextInS3(s3Key, messageContentStr, messageContentSize);
 
-		LOG.info("S3 object created, Bucket name: " + clientConfiguration.getS3BucketName() + ", Object key: " + s3Key
-				+ ".");
+		LOG.info("S3 object created, Bucket name: " + clientConfiguration.getS3BucketName() + ", Object key: " + s3Key + ".");
 
 		// Convert S3 pointer (bucket name, key, etc) to JSON string
 		MessageS3Pointer s3Pointer = new MessageS3Pointer(clientConfiguration.getS3BucketName(), s3Key);
@@ -1108,13 +1031,11 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		MessageAttributeValue messageAttributeValue = new MessageAttributeValue();
 		messageAttributeValue.setDataType("Number");
 		messageAttributeValue.setStringValue(messageContentSize.toString());
-		sendMessageRequest.addMessageAttributesEntry(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME,
-				messageAttributeValue);
+		sendMessageRequest.addMessageAttributesEntry(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, messageAttributeValue);
 
 		// Store the message content in S3.
 		storeTextInS3(s3Key, messageContentStr, messageContentSize);
-		LOG.info("S3 object created, Bucket name: " + clientConfiguration.getS3BucketName() + ", Object key: " + s3Key
-				+ ".");
+		LOG.info("S3 object created, Bucket name: " + clientConfiguration.getS3BucketName() + ", Object key: " + s3Key + ".");
 
 		// Convert S3 pointer (bucket name, key, etc) to JSON string
 		MessageS3Pointer s3Pointer = new MessageS3Pointer(clientConfiguration.getS3BucketName(), s3Key);
@@ -1144,8 +1065,10 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		InputStream messageContentStream = new ByteArrayInputStream(messageContentStr.getBytes(StandardCharsets.UTF_8));
 		ObjectMetadata messageContentStreamMetadata = new ObjectMetadata();
 		messageContentStreamMetadata.setContentLength(messageContentSize);
-		PutObjectRequest putObjectRequest = new PutObjectRequest(clientConfiguration.getS3BucketName(), s3Key,
-				messageContentStream, messageContentStreamMetadata);
+		PutObjectRequest putObjectRequest = new PutObjectRequest(clientConfiguration.getS3BucketName(),
+																														 s3Key,
+																														 messageContentStream,
+																														 messageContentStreamMetadata);
 		try {
 			clientConfiguration.getAmazonS3Client().putObject(putObjectRequest);
 		} catch (AmazonServiceException e) {
@@ -1178,7 +1101,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	public ChangeMessageVisibilityBatchResult changeMessageVisibilityBatch(String queueUrl,
 																																				 List<ChangeMessageVisibilityBatchRequestEntry> entries)
 					throws AmazonServiceException {
-		return super.changeMessageVisibilityBatch(queueUrl, removeEmbedS3PointerFromVisibilityBatchEntries(entries));
+		return changeMessageVisibilityBatch(new ChangeMessageVisibilityBatchRequest(queueUrl, entries));
 	}
 
 	@Override
@@ -1192,7 +1115,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 
 	private List<ChangeMessageVisibilityBatchRequestEntry> removeEmbedS3PointerFromVisibilityBatchEntries(
 					List<ChangeMessageVisibilityBatchRequestEntry> entries) {
-		List<ChangeMessageVisibilityBatchRequestEntry> withOrigReceiptHandles = new ArrayList<>();
+		List<ChangeMessageVisibilityBatchRequestEntry> withOrigReceiptHandles = new ArrayList<ChangeMessageVisibilityBatchRequestEntry>();
 		for (ChangeMessageVisibilityBatchRequestEntry entry : entries) {
 			if (isS3ReceiptHandle(entry.getReceiptHandle())) {
 				withOrigReceiptHandles.add(new ChangeMessageVisibilityBatchRequestEntry(entry.getId(),
@@ -1207,9 +1130,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 	@Override
 	public void changeMessageVisibility(String queueUrl, String receiptHandle, Integer visibilityTimeout)
 					throws AmazonServiceException {
-		super.changeMessageVisibility(queueUrl,
-																	isS3ReceiptHandle(receiptHandle) ? getOrigReceiptHandle(receiptHandle) : receiptHandle,
-																	visibilityTimeout);
+		changeMessageVisibility(new ChangeMessageVisibilityRequest(queueUrl, receiptHandle, visibilityTimeout));
 	}
 
 	@Override

--- a/src/main/java/com/amazon/sqs/javamessaging/MessageS3Pointer.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/MessageS3Pointer.java
@@ -24,13 +24,15 @@ package com.amazon.sqs.javamessaging;
 class MessageS3Pointer {
 	private String s3BucketName;
 	private String s3Key;
+	private String targetMd5;
 
 	public MessageS3Pointer() {
 	}
 
-	public MessageS3Pointer(String s3BucketName, String s3Key) {
+	public MessageS3Pointer(String s3BucketName, String s3Key, String targetMd5) {
 		this.s3BucketName = s3BucketName;
 		this.s3Key = s3Key;
+		this.targetMd5 = targetMd5;
 	}
 
 	public String getS3BucketName() {
@@ -49,4 +51,11 @@ class MessageS3Pointer {
 		this.s3Key = s3Key;
 	}
 
+	public String getTargetMd5() {
+		return targetMd5;
+	}
+
+	public void setTargetMd5(String targetMd5) {
+		this.targetMd5 = targetMd5;
+	}
 }

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -191,7 +191,7 @@ public class AmazonSQSExtendedClientTest {
 
 		Message message = new Message();
 		message.withBody("[\"com.amazon.sqs.javamessaging.MessageS3Pointer\"," + "{\"s3BucketName\":\"test-bucket-name\","
-										 + "\"s3Key\":\"7f096cb3-454d-4bd8-923d-8948a300f1c1\",\"md5\":\"" +
+										 + "\"s3Key\":\"7f096cb3-454d-4bd8-923d-8948a300f1c1\",\"targetMd5\":\"" +
 										 Base64.encodeAsString(DigestUtils.md5(messageBody)) + "\"}]");
 		message.addMessageAttributesEntry(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME,
 																			new MessageAttributeValue().withDataType("Number")

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -17,7 +17,9 @@ package com.amazon.sqs.javamessaging;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
@@ -27,7 +29,17 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClient;
-import com.amazonaws.services.sqs.model.*;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequest;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityBatchRequestEntry;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
+import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
 
 import com.amazonaws.util.Base64;
 import org.apache.commons.codec.digest.DigestUtils;

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -15,21 +15,25 @@
 
 package com.amazon.sqs.javamessaging;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClient;
-import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
-import com.amazonaws.services.sqs.model.SendMessageBatchRequestEntry;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.model.*;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -43,23 +47,37 @@ import static org.mockito.Mockito.isA;
  */
 public class AmazonSQSExtendedClientTest {
 
-    private AmazonSQS sqs;
-    private AmazonS3 s3;
-    private static final String S3_BUCKET_NAME = "test-bucket-name";
-    private static final String SQS_QUEUE_URL = "test-queue-url";
-    private static final int SQS_SIZE_LIMIT = 262144;
+	private AmazonSQS sqs;
 
-    @Before
-    public void setupClient() {
-        s3 = mock(AmazonS3.class);
-        when(s3.putObject(isA(PutObjectRequest.class))).thenReturn(null);
+	private AmazonSQS wrappedSQS;
 
-        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
-                .withLargePayloadSupportEnabled(s3, S3_BUCKET_NAME);
+	private AmazonS3 s3;
 
-        sqs = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
+	private static final String S3_BUCKET_NAME = "test-bucket-name";
 
-    }
+	private static final String SQS_QUEUE_URL = "test-queue-url";
+
+	private static final int SQS_SIZE_LIMIT = 262144;
+
+	public static final String MESSAGE_HANDLE = "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw\n"
+																							+ "Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE\n"
+																							+ "auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=";
+
+	public static final String LARGE_MESSAGE_HANDLE =
+					"-..s3BucketName..-test-bucket-name-..s3BucketName..--..s3Key..-7f096cb3-454d-4bd8-923d-8948a300f1c1-..s3Key..-"
+					+ MESSAGE_HANDLE;
+
+	@Before
+	public void setupClient() {
+		s3 = mock(AmazonS3.class);
+		when(s3.putObject(isA(PutObjectRequest.class))).thenReturn(null);
+
+		ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration().withLargePayloadSupportEnabled(s3,
+																																																															 S3_BUCKET_NAME);
+		wrappedSQS = mock(AmazonSQSClient.class);
+		sqs = new AmazonSQSExtendedClient(wrappedSQS, extendedClientConfiguration);
+
+	}
 
 	@Test
 	public void testSendLargeMessage() {
@@ -71,6 +89,7 @@ public class AmazonSQSExtendedClientTest {
 
 		sqs.sendMessage(messageRequest);
 		verify(s3, times(1)).putObject(isA(PutObjectRequest.class));
+
 	}
 
 	@Test
@@ -83,51 +102,52 @@ public class AmazonSQSExtendedClientTest {
 		verify(s3, never()).putObject(isA(PutObjectRequest.class));
 	}
 
-    @Test
-    public void testSendMessageWithLargePayloadSupportDisabled() {
-        int messageLength = 300000;
-        String messageBody = generateString(messageLength);
+	@Test
+	public void testSendMessageWithLargePayloadSupportDisabled() {
+		int messageLength = 300000;
+		String messageBody = generateString(messageLength);
 
-        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
-                .withLargePayloadSupportDisabled();
+		ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration().withLargePayloadSupportDisabled();
 
-        AmazonSQS sqsExtended = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
+		AmazonSQS sqsExtended = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
 
-        SendMessageRequest messageRequest = new SendMessageRequest(SQS_QUEUE_URL, messageBody);
-        sqsExtended.sendMessage(messageRequest);
-        verify(s3, never()).putObject(isA(PutObjectRequest.class));
-    }
+		SendMessageRequest messageRequest = new SendMessageRequest(SQS_QUEUE_URL, messageBody);
+		sqsExtended.sendMessage(messageRequest);
+		verify(s3, never()).putObject(isA(PutObjectRequest.class));
+	}
 
-    @Test
-    public void testSendMessageWithAlwaysThroughS3() {
-        int messageLength = 3;
-        String messageBody = generateString(messageLength);
+	@Test
+	public void testSendMessageWithAlwaysThroughS3() {
+		int messageLength = 3;
+		String messageBody = generateString(messageLength);
 
-        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
-                .withLargePayloadSupportEnabled(s3, S3_BUCKET_NAME).withAlwaysThroughS3(true);
+		ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration().withLargePayloadSupportEnabled(s3,
+																																																															 S3_BUCKET_NAME)
+																																															 .withAlwaysThroughS3(true);
 
-        AmazonSQS sqsExtended = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
+		AmazonSQS sqsExtended = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
 
 
-        SendMessageRequest messageRequest = new SendMessageRequest(SQS_QUEUE_URL, messageBody);
-        sqsExtended.sendMessage(messageRequest);
-        verify(s3, times(1)).putObject(isA(PutObjectRequest.class));
-    }
+		SendMessageRequest messageRequest = new SendMessageRequest(SQS_QUEUE_URL, messageBody);
+		sqsExtended.sendMessage(messageRequest);
+		verify(s3, times(1)).putObject(isA(PutObjectRequest.class));
+	}
 
-    @Test
-    public void testSendMessageWithSetMessageSizeThreshold() {
-        int messageLength = 1000;
-        String messageBody = generateString(messageLength);
+	@Test
+	public void testSendMessageWithSetMessageSizeThreshold() {
+		int messageLength = 1000;
+		String messageBody = generateString(messageLength);
 
-        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
-                .withLargePayloadSupportEnabled(s3, S3_BUCKET_NAME).withMessageSizeThreshold(500);
+		ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration().withLargePayloadSupportEnabled(s3,
+																																																															 S3_BUCKET_NAME)
+																																															 .withMessageSizeThreshold(500);
 
-        AmazonSQS sqsExtended = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
+		AmazonSQS sqsExtended = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
 
-        SendMessageRequest messageRequest = new SendMessageRequest(SQS_QUEUE_URL, messageBody);
-        sqsExtended.sendMessage(messageRequest);
-        verify(s3, times(1)).putObject(isA(PutObjectRequest.class));
-    }
+		SendMessageRequest messageRequest = new SendMessageRequest(SQS_QUEUE_URL, messageBody);
+		sqsExtended.sendMessage(messageRequest);
+		verify(s3, times(1)).putObject(isA(PutObjectRequest.class));
+	}
 
 	@Test
 	public void testMessageBatch() {
@@ -144,8 +164,133 @@ public class AmazonSQSExtendedClientTest {
 		}
 
 		SendMessageBatchRequest batchRequest = new SendMessageBatchRequest(SQS_QUEUE_URL, batchEntries);
-        sqs.sendMessageBatch(batchRequest);
+		sqs.sendMessageBatch(batchRequest);
 		verify(s3, times(8)).putObject(isA(PutObjectRequest.class));
+	}
+
+	@Test
+	public void testReceiveLargeMessage() {
+
+		int messageLength = 300000;
+		String messageBody = generateString(messageLength);
+
+		Message message = new Message();
+		message.withBody("[\"com.amazon.sqs.javamessaging.MessageS3Pointer\"," + "{\"s3BucketName\":\"test-bucket-name\","
+										 + "\"s3Key\":\"7f096cb3-454d-4bd8-923d-8948a300f1c1\"}]");
+		message.addMessageAttributesEntry(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME,
+																			new MessageAttributeValue().withDataType("Number")
+																																 .withStringValue(Integer.toString(messageBody.getBytes(
+																																				 StandardCharsets.UTF_8).length)));
+
+		S3Object s3Body = new S3Object();
+		s3Body.setObjectContent(new ByteArrayInputStream(messageBody.getBytes(StandardCharsets.UTF_8)));
+
+		when(wrappedSQS.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(new ReceiveMessageResult().withMessages(message));
+		when(s3.getObject(any(GetObjectRequest.class))).thenReturn(s3Body);
+
+		ReceiveMessageResult receiveMessageResult = sqs.receiveMessage(SQS_QUEUE_URL);
+		// aws request objects lack equals methods for matcher verification
+		ArgumentCaptor<GetObjectRequest> getObjectArgument = ArgumentCaptor.forClass(GetObjectRequest.class);
+		verify(wrappedSQS, times(1)).receiveMessage(isA(ReceiveMessageRequest.class));
+		verify(s3, times(1)).getObject(getObjectArgument.capture());
+		Assert.assertEquals("7f096cb3-454d-4bd8-923d-8948a300f1c1", getObjectArgument.getValue().getKey());
+		Assert.assertEquals(receiveMessageResult.getMessages().size(), 1);
+		Assert.assertEquals(messageBody, receiveMessageResult.getMessages().get(0).getBody());
+	}
+
+	@Test
+	public void testReceiveSmallMessage() {
+		Message message = new Message();
+		message.withBody("not a large body");
+
+		when(wrappedSQS.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(new ReceiveMessageResult().withMessages(message));
+
+		sqs.receiveMessage(SQS_QUEUE_URL);
+		verify(wrappedSQS, times(1)).receiveMessage(isA(ReceiveMessageRequest.class));
+		verify(s3, never()).getObject(any(GetObjectRequest.class));
+	}
+
+	@Test
+	public void testDeleteLargeMessage() {
+		String messageHandle = "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw\n"
+													 + "Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE\n"
+													 + "auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=";
+		String largeMessageHandle =
+						"-..s3BucketName..-test-bucket-name-..s3BucketName..--..s3Key..-7f096cb3-454d-4bd8-923d-8948a300f1c1-..s3Key..-"
+						+ messageHandle;
+
+		sqs.deleteMessage(SQS_QUEUE_URL, largeMessageHandle);
+		// aws request objects lack equals methods for matcher verification
+		ArgumentCaptor<DeleteObjectRequest> deleteObjectArgument = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		ArgumentCaptor<DeleteMessageRequest> deleteMessageArgument = ArgumentCaptor.forClass(DeleteMessageRequest.class);
+		verify(s3, times(1)).deleteObject(deleteObjectArgument.capture());
+		verify(wrappedSQS, times(1)).deleteMessage(deleteMessageArgument.capture());
+		Assert.assertEquals("7f096cb3-454d-4bd8-923d-8948a300f1c1",
+												deleteObjectArgument.getValue().getKey(),
+												"7f096cb3-454d-4bd8-923d-8948a300f1c1");
+		Assert.assertEquals(messageHandle, deleteMessageArgument.getValue().getReceiptHandle());
+	}
+
+	@Test
+	public void testDeleteSmallMessage() {
+		String messageHandle = "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw\n"
+													 + "Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE\n"
+													 + "auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=";
+
+		sqs.deleteMessage(SQS_QUEUE_URL, messageHandle);
+		// aws request objects lack equals methods for matcher verification
+		ArgumentCaptor<DeleteMessageRequest> deleteMessageArgument = ArgumentCaptor.forClass(DeleteMessageRequest.class);
+		verify(s3, never()).deleteObject(isA(DeleteObjectRequest.class));
+		verify(wrappedSQS, times(1)).deleteMessage(deleteMessageArgument.capture());
+		Assert.assertEquals(messageHandle, deleteMessageArgument.getValue().getReceiptHandle());
+	}
+
+	@Test
+	public void testChangeMessageVisibilityLargeMessage() {
+		String messageHandle = "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw\n"
+													 + "Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE\n"
+													 + "auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=";
+		String largeMessageHandle =
+						"-..s3BucketName..-test-bucket-name-..s3BucketName..--..s3Key..-7f096cb3-454d-4bd8-923d-8948a300f1c1-..s3Key..-"
+						+ messageHandle;
+
+		sqs.changeMessageVisibility(SQS_QUEUE_URL, largeMessageHandle, 10);
+		// aws request objects lack equals methods for matcher verification
+		ArgumentCaptor<ChangeMessageVisibilityRequest> changeVisibilityArgument = ArgumentCaptor.forClass(
+						ChangeMessageVisibilityRequest.class);
+		verify((wrappedSQS), times(1)).changeMessageVisibility(changeVisibilityArgument.capture());
+		Assert.assertEquals(messageHandle, changeVisibilityArgument.getValue().getReceiptHandle());
+	}
+
+	@Test
+	public void testChangeMessageVisibilitySmallMessage() {
+		String messageHandle = "MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+Cw\n"
+													 + "Lj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QE\n"
+													 + "auMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0=";
+
+		sqs.changeMessageVisibility(SQS_QUEUE_URL, messageHandle, 10);
+		// aws request objects lack equals methods for matcher verification
+		ArgumentCaptor<ChangeMessageVisibilityRequest> changeVisibilityArgument = ArgumentCaptor.forClass(
+						ChangeMessageVisibilityRequest.class);
+		verify(wrappedSQS, times(1)).changeMessageVisibility(changeVisibilityArgument.capture());
+		Assert.assertEquals(messageHandle, changeVisibilityArgument.getValue().getReceiptHandle());
+	}
+
+	@Test
+	public void testChangeMessageVisibilityBatch() {
+
+		List<ChangeMessageVisibilityBatchRequestEntry> entries = new ArrayList<ChangeMessageVisibilityBatchRequestEntry>();
+		for (int k = 0; k < 3; k++) {
+			entries.add(new ChangeMessageVisibilityBatchRequestEntry(Integer.toString(k), LARGE_MESSAGE_HANDLE));
+		}
+		ArgumentCaptor<ChangeMessageVisibilityBatchRequest> changeVisibilityArgument = ArgumentCaptor.forClass(
+						ChangeMessageVisibilityBatchRequest.class);
+		sqs.changeMessageVisibilityBatch(new ChangeMessageVisibilityBatchRequest(SQS_QUEUE_URL, entries));
+		verify(wrappedSQS, times(1)).changeMessageVisibilityBatch(changeVisibilityArgument.capture());
+		for (ChangeMessageVisibilityBatchRequestEntry entry : changeVisibilityArgument.getValue().getEntries()) {
+			Assert.assertEquals(MESSAGE_HANDLE, entry.getReceiptHandle());
+		}
+
 	}
 
 	private String generateString(int messageLength) {


### PR DESCRIPTION
Fixed missing wrapper methods for update message visibility. The modified message handle  prevented calls to the underlying SQS client from succeeding.

Fixed incorrect message md5 hash. The md5 returned with the message previously was the md5 of the messageS3Pointer json not the large message offloaded to s3. This would result in any comparisons between the external view of the message content and the presented md5 failing. Ive added a quick fix which when the message content is large takes the s3 generated md5 hash and puts it in the messageS3Pointer. This is then retrieved on message receipt and replaces the hash in the message. The large message md5 behavior is therefore transparent to users of the lib and should function as the underling client would. (there is a risk if the hashing method of S3 and SQS differ in the future but the content hash could easily be manually calculated as a fix).
