### PR TITLE
Make the key generator configurable

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.Map.Entry;
 
 import com.amazonaws.AmazonClientException;
@@ -1250,7 +1249,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 
 		checkMessageAttributes(batchEntry.getMessageAttributes());
 
-		String s3Key = UUID.randomUUID().toString();
+		String s3Key = clientConfiguration.getKeyGenerator().generate();
 
 		// Read the content of the message from message body
 		String messageContentStr = batchEntry.getMessageBody();
@@ -1283,7 +1282,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 
 		checkMessageAttributes(sendMessageRequest.getMessageAttributes());
 
-		String s3Key = UUID.randomUUID().toString();
+		String s3Key = clientConfiguration.getKeyGenerator().generate();
 
 		// Read the content of the message from message body
 		String messageContentStr = sendMessageRequest.getMessageBody();

--- a/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
@@ -21,8 +21,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.annotation.NotThreadSafe;
 
-import java.util.List;
-
 /**
  * Amazon SQS extended client configuration options such as Amazon S3 client,
  * bucket name, and message size threshold for large-payload messages.
@@ -36,6 +34,7 @@ public class ExtendedClientConfiguration {
 	private boolean largePayloadSupport = false;
 	private boolean alwaysThroughS3 = false;
 	private int messageSizeThreshold = SQSExtendedClientConstants.DEFAULT_MESSAGE_SIZE_THRESHOLD;
+	private KeyGenerator keyGenerator = KeyGenerator.DEFAULT_KEY_GENERATOR;
 
 	public ExtendedClientConfiguration() {
 		s3 = null;
@@ -48,6 +47,7 @@ public class ExtendedClientConfiguration {
 		this.largePayloadSupport = other.largePayloadSupport;
 		this.alwaysThroughS3 = other.alwaysThroughS3;
 		this.messageSizeThreshold = other.messageSizeThreshold;
+		this.keyGenerator = other.keyGenerator;
 	}
 
 	/**
@@ -176,6 +176,40 @@ public class ExtendedClientConfiguration {
 	 */
 	public int getMessageSizeThreshold() {
 		return messageSizeThreshold;
+	}
+
+	/**
+	 * Sets the key generator for storing message payloads in Amazon S3.
+	 *
+	 * @param keyGenerator
+	 *            The key generator to be used for storing in Amazon S3.
+	 *            Default: {@link KeyGenerator#DEFAULT_KEY_GENERATOR}.
+	 */
+	public void setKeyGenerator(KeyGenerator keyGenerator) {
+		this.keyGenerator = keyGenerator;
+	}
+
+	/**
+	 * Sets the key generator for storing message payloads in Amazon S3.
+	 *
+	 * @param keyGenerator
+	 *            The key generator to be used for storing in Amazon S3.
+	 *            Default: {@link KeyGenerator#DEFAULT_KEY_GENERATOR}.
+	 * @return the updated ExtendedClientConfiguration object.
+	 */
+	public ExtendedClientConfiguration withKeyGenerator(KeyGenerator keyGenerator) {
+		setKeyGenerator(keyGenerator);
+		return this;
+	}
+
+	/**
+	 * Gets the key generator for storing message payloads in Amazon S3.
+	 *
+	 * @return The key generator to be used for storing in Amazon S3.
+	 *            Default: {@link KeyGenerator#DEFAULT_KEY_GENERATOR}.
+	 */
+	public KeyGenerator getKeyGenerator() {
+		return keyGenerator;
 	}
 
 	/**

--- a/src/main/java/com/amazon/sqs/javamessaging/KeyGenerator.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/KeyGenerator.java
@@ -1,0 +1,20 @@
+package com.amazon.sqs.javamessaging;
+
+import java.util.UUID;
+
+/**
+ * Class for generating keys for storing messages to Amazon S3.
+ */
+public class KeyGenerator {
+
+    public static final KeyGenerator DEFAULT_KEY_GENERATOR = new KeyGenerator();
+
+    /**
+     * Generates a unique for use when storing to Amazon S3.
+     *
+     * @return a unique key for writing to S3.
+     */
+    public String generate() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -85,6 +85,22 @@ public class AmazonSQSExtendedClientTest {
     }
 
     @Test
+    public void testWhenSendLargeMessageThenKeyIsFromKeyGenerator() {
+        int messageLength = LESS_THAN_SQS_SIZE_LIMIT;
+        String messageBody = generateStringWithLength(messageLength);
+        KeyGenerator keyGenerator = spy(new KeyGenerator());
+        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
+                .withLargePayloadSupportEnabled(mockS3, S3_BUCKET_NAME).withAlwaysThroughS3(true)
+                .withKeyGenerator(keyGenerator);
+        AmazonSQS sqsExtended = spy(new AmazonSQSExtendedClient(mock(AmazonSQSClient.class), extendedClientConfiguration));
+
+        SendMessageRequest messageRequest = new SendMessageRequest(SQS_QUEUE_URL, messageBody);
+        sqsExtended.sendMessage(messageRequest);
+
+        verify(keyGenerator, times(1)).generate();
+    }
+
+    @Test
     public void testWhenSendSmallMessageThenS3IsNotUsed() {
         int messageLength = SQS_SIZE_LIMIT;
         String messageBody = generateStringWithLength(messageLength);

--- a/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
@@ -43,11 +43,13 @@ public class ExtendedClientConfigurationTest {
 
         boolean alwaysThroughS3 = true;
         int messageSizeThreshold = 500;
+        KeyGenerator keyGenerator = new KeyGenerator();
 
         ExtendedClientConfiguration extendedClientConfig = new ExtendedClientConfiguration();
 
         extendedClientConfig.withLargePayloadSupportEnabled(s3, s3BucketName)
-                .withAlwaysThroughS3(alwaysThroughS3).withMessageSizeThreshold(messageSizeThreshold);
+                .withAlwaysThroughS3(alwaysThroughS3).withMessageSizeThreshold(messageSizeThreshold)
+                .withKeyGenerator(keyGenerator);
 
         ExtendedClientConfiguration newExtendedClientConfig = new ExtendedClientConfiguration(extendedClientConfig);
 
@@ -56,6 +58,7 @@ public class ExtendedClientConfigurationTest {
         Assert.assertTrue(newExtendedClientConfig.isLargePayloadSupportEnabled());
         Assert.assertEquals(alwaysThroughS3, newExtendedClientConfig.isAlwaysThroughS3());
         Assert.assertEquals(messageSizeThreshold, newExtendedClientConfig.getMessageSizeThreshold());
+        Assert.assertEquals(keyGenerator, newExtendedClientConfig.getKeyGenerator());
 
         Assert.assertNotSame(newExtendedClientConfig, extendedClientConfig);
     }


### PR DESCRIPTION
Needed if you want a key that is prepended with a path within the bucket.

Right now we have to capture the message in a delegating SQS client, re-write the JSON, and do something equally ugly for S3.

Cheers!