### PR TITLE
Fixes #10: Allow configuring server-side encryption (SSE) for S3 objects

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -1331,7 +1331,8 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		ObjectMetadata messageContentStreamMetadata = new ObjectMetadata();
 		messageContentStreamMetadata.setContentLength(messageContentSize);
 		PutObjectRequest putObjectRequest = new PutObjectRequest(clientConfiguration.getS3BucketName(), s3Key,
-				messageContentStream, messageContentStreamMetadata);
+				messageContentStream, messageContentStreamMetadata)
+				.withSSEAwsKeyManagementParams(clientConfiguration.getSSEKeyManagementParams());
 		try {
 			clientConfiguration.getAmazonS3Client().putObject(putObjectRequest);
 		} catch (AmazonServiceException e) {

--- a/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
@@ -17,6 +17,7 @@ package com.amazon.sqs.javamessaging;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.annotation.NotThreadSafe;
@@ -36,6 +37,7 @@ public class ExtendedClientConfiguration {
 	private boolean largePayloadSupport = false;
 	private boolean alwaysThroughS3 = false;
 	private int messageSizeThreshold = SQSExtendedClientConstants.DEFAULT_MESSAGE_SIZE_THRESHOLD;
+	private SSEAwsKeyManagementParams sseKeyManagementParams;
 
 	public ExtendedClientConfiguration() {
 		s3 = null;
@@ -48,6 +50,7 @@ public class ExtendedClientConfiguration {
 		this.largePayloadSupport = other.largePayloadSupport;
 		this.alwaysThroughS3 = other.alwaysThroughS3;
 		this.messageSizeThreshold = other.messageSizeThreshold;
+		this.sseKeyManagementParams = other.sseKeyManagementParams;
 	}
 
 	/**
@@ -213,5 +216,39 @@ public class ExtendedClientConfiguration {
 	 */
 	public boolean isAlwaysThroughS3() {
 		return alwaysThroughS3;
+	}
+
+	/**
+	 * Sets the SSEAwsKeyManagementParams to be used for requesting server-side encryption of S3 objects.
+	 *
+	 * @param sseKeyManagementParams
+	 *            Parameters to be used for requesting server-side encryption of S3 objects. Default: No server-side
+	 *            encryption.
+	 */
+	public void setSSEKeyManagementParams(SSEAwsKeyManagementParams sseKeyManagementParams) {
+		this.sseKeyManagementParams = sseKeyManagementParams;
+	}
+
+	/**
+	 * Sets the SSEAwsKeyManagementParams to be used for requesting server-side encryption of S3 objects.
+	 *
+	 * @param sseKeyManagementParams
+	 *            Parameters to be used for requesting server-side encryption of S3 objects. Default: No server-side
+	 *            encryption.
+	 * @return the updated ExtendedClientConfiguration object.
+	 */
+	public ExtendedClientConfiguration withSSEKeyManagementParams(SSEAwsKeyManagementParams sseKeyManagementParams) {
+		setSSEKeyManagementParams(sseKeyManagementParams);
+		return this;
+	}
+
+	/**
+	 * Gets the SSEAwsKeyManagementParams to be used for requesting server-side encryption of S3 objects.
+	 *
+	 * @return Parameters to be used for requesting server-side encryption of S3 objects. Default: No server-side
+	 *         encryption.
+	 */
+	public SSEAwsKeyManagementParams getSSEKeyManagementParams() {
+		return sseKeyManagementParams; 
 	}
 }

--- a/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
@@ -17,6 +17,7 @@ package com.amazon.sqs.javamessaging;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.*;
 public class ExtendedClientConfigurationTest {
 
     private static String s3BucketName = "test-bucket-name";
+    private static String s3KeyId = "test-key-id";
 
     @Before
     public void setup() {
@@ -43,11 +45,13 @@ public class ExtendedClientConfigurationTest {
 
         boolean alwaysThroughS3 = true;
         int messageSizeThreshold = 500;
+        SSEAwsKeyManagementParams sseKeyManagementParams = new SSEAwsKeyManagementParams(s3KeyId);
 
         ExtendedClientConfiguration extendedClientConfig = new ExtendedClientConfiguration();
 
         extendedClientConfig.withLargePayloadSupportEnabled(s3, s3BucketName)
-                .withAlwaysThroughS3(alwaysThroughS3).withMessageSizeThreshold(messageSizeThreshold);
+                .withAlwaysThroughS3(alwaysThroughS3).withMessageSizeThreshold(messageSizeThreshold)
+                .withSSEKeyManagementParams(sseKeyManagementParams);
 
         ExtendedClientConfiguration newExtendedClientConfig = new ExtendedClientConfiguration(extendedClientConfig);
 
@@ -56,6 +60,7 @@ public class ExtendedClientConfigurationTest {
         Assert.assertTrue(newExtendedClientConfig.isLargePayloadSupportEnabled());
         Assert.assertEquals(alwaysThroughS3, newExtendedClientConfig.isAlwaysThroughS3());
         Assert.assertEquals(messageSizeThreshold, newExtendedClientConfig.getMessageSizeThreshold());
+        Assert.assertEquals(sseKeyManagementParams, newExtendedClientConfig.getSSEKeyManagementParams());
 
         Assert.assertNotSame(newExtendedClientConfig, extendedClientConfig);
     }
@@ -116,5 +121,16 @@ public class ExtendedClientConfigurationTest {
 
     }
 
+    @Test
+    public void testSseKeyManagementParams() {
+
+        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration();
+
+        Assert.assertNull(extendedClientConfiguration.getSSEKeyManagementParams());
+
+        extendedClientConfiguration.setSSEKeyManagementParams(new SSEAwsKeyManagementParams(s3KeyId));
+        Assert.assertEquals(s3KeyId, extendedClientConfiguration.getSSEKeyManagementParams().getAwsKmsKeyId());
+
+    }
 
 }


### PR DESCRIPTION
Allow specifying a custom KMS key to be used for SSE, or using the default `aws/s3` key. The default remains no SSE as before.


`keyManagementParams` using KMS CMK alias:
```
SSEAwsKeyManagementParams keyManagementParams = new SSEAwsKeyManagementParams("alias/some_key_alias");
```

`keyManagementParams` using KMS CMK key id:
```
SSEAwsKeyManagementParams keyManagementParams = new SSEAwsKeyManagementParams("0000aaaa-bb11-cc22-dd33-ffffff444444");
```
`keyManagementParams` using default S3 KMS key:
```
SSEAwsKeyManagementParams keyManagementParams = new SSEAwsKeyManagementParams();
```

Adding to `ExtendedClientConfiguration`:
```
ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
        .withLargePayloadSupportEnabled(s3Client, "some-bucket-name")
        .withSSEKeyManagementParams(keyManagementParams);
```

Backwards-compatible, no server-side-encryption:
```
ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
        .withLargePayloadSupportEnabled(s3Client, "some-bucket-name");
```