### PR TITLE
Prevent a batch of messages going over the threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+.idea/
+*.iml


### PR DESCRIPTION
*Issue #24*

*Description of changes:*

I noticed that the sum of the message sizes in the batch could still go over the threshold, so I've added support, and tests, for this to be prevented. I'll comment on the PR in order to explain the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
