### PR TITLE
Allow Clients to modify the PutObjectRequests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -1335,7 +1335,8 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
 		PutObjectRequest putObjectRequest = new PutObjectRequest(clientConfiguration.getS3BucketName(), s3Key,
 				messageContentStream, messageContentStreamMetadata);
 		try {
-			clientConfiguration.getAmazonS3Client().putObject(putObjectRequest);
+			PutObjectRequest clientModifiedPutRequest = clientConfiguration.getPutObjectModifier().apply(putObjectRequest);
+			clientConfiguration.getAmazonS3Client().putObject(clientModifiedPutRequest);
 		} catch (AmazonServiceException e) {
 			String errorMessage = "Failed to store the message content in an S3 object. SQS message was not sent.";
 			LOG.error(errorMessage, e);

--- a/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
@@ -16,12 +16,12 @@
 package com.amazon.sqs.javamessaging;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.internal.SdkFunction;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import com.amazonaws.annotation.NotThreadSafe;
-
-import java.util.List;
 
 /**
  * Amazon SQS extended client configuration options such as Amazon S3 client,
@@ -36,6 +36,7 @@ public class ExtendedClientConfiguration {
 	private boolean largePayloadSupport = false;
 	private boolean alwaysThroughS3 = false;
 	private int messageSizeThreshold = SQSExtendedClientConstants.DEFAULT_MESSAGE_SIZE_THRESHOLD;
+	private SdkFunction<PutObjectRequest, PutObjectRequest> putObjectModifier = new PutObjectRequestIdentityFunction();
 
 	public ExtendedClientConfiguration() {
 		s3 = null;
@@ -48,6 +49,7 @@ public class ExtendedClientConfiguration {
 		this.largePayloadSupport = other.largePayloadSupport;
 		this.alwaysThroughS3 = other.alwaysThroughS3;
 		this.messageSizeThreshold = other.messageSizeThreshold;
+		this.putObjectModifier = other.putObjectModifier;
 	}
 
 	/**
@@ -213,5 +215,46 @@ public class ExtendedClientConfiguration {
 	 */
 	public boolean isAlwaysThroughS3() {
 		return alwaysThroughS3;
+	}
+
+	/**
+	 * Sets the function which you can use to modify the PutObjectRequest to enable support for encryption headers,
+	 * meta-data, etc.
+	 *
+	 * @param putObjectModifier
+	 *            An implementation of the internal SdkFunction which takes a PutObjectRequest, modifies it, and returns it.
+	 */
+	public void setPutObjectModifier(SdkFunction<PutObjectRequest, PutObjectRequest> putObjectModifier)
+	{
+		this.putObjectModifier = putObjectModifier;
+	}
+
+	/**
+	 * Sets the function which you can use to modify the PutObjectRequest to enable support for encryption headers,
+	 * meta-data, etc.
+	 *
+	 * @param putObjectModifier
+	 *            An implementation of the internal SdkFunction which takes a PutObjectRequest, modifies it, and returns it.
+	 */
+	public ExtendedClientConfiguration withPutObjectModifier(SdkFunction<PutObjectRequest, PutObjectRequest> putObjectModifier) {
+		this.setPutObjectModifier(putObjectModifier);
+		return this;
+	}
+
+	/**
+	 * Used to return the function which modifies the PutObjectRequests
+	 *
+	 * @return The custom configured SdkFunction or an identity function by default.
+	 *         stored in Amazon S3. Default: false
+	 */
+	public SdkFunction<PutObjectRequest, PutObjectRequest> getPutObjectModifier() {
+		return putObjectModifier;
+	}
+
+	static class PutObjectRequestIdentityFunction implements SdkFunction<PutObjectRequest, PutObjectRequest> {
+		@Override
+		public PutObjectRequest apply(PutObjectRequest putObjectRequest) {
+			return putObjectRequest;
+		}
 	}
 }

--- a/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
@@ -15,6 +15,7 @@
 
 package com.amazon.sqs.javamessaging;
 
+import com.amazonaws.internal.SdkFunction;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import junit.framework.Assert;
@@ -32,7 +33,6 @@ public class ExtendedClientConfigurationTest {
 
     @Before
     public void setup() {
-
     }
 
     @Test
@@ -116,5 +116,49 @@ public class ExtendedClientConfigurationTest {
 
     }
 
+    @Test
+    public void identityFunction_doesNotModifyInput()
+    {
+        ExtendedClientConfiguration.PutObjectRequestIdentityFunction identityFunction = new ExtendedClientConfiguration.PutObjectRequestIdentityFunction();
+        PutObjectRequest inputRequest = mock(PutObjectRequest.class);
+        PutObjectRequest outputRequest = identityFunction.apply(inputRequest);
+        Assert.assertSame(inputRequest, outputRequest);
+        verifyZeroInteractions(inputRequest);
+    }
 
+    @Test
+    public void noPutObjectFunctionDefined_useIdentity()
+    {
+        ExtendedClientConfiguration configuration = new ExtendedClientConfiguration();
+        Assert.assertEquals(configuration.getPutObjectModifier().getClass(), ExtendedClientConfiguration.PutObjectRequestIdentityFunction.class);
+    }
+
+    @Test
+    public void testPutObjectFunctionSetter()
+    {
+        ExtendedClientConfiguration configuration = new ExtendedClientConfiguration();
+        SdkFunction<PutObjectRequest, PutObjectRequest> modifierFunction = new SdkFunction<PutObjectRequest, PutObjectRequest>() {
+            @Override
+            public PutObjectRequest apply(PutObjectRequest putObjectRequest) {
+                return null;
+            }
+        };
+
+        configuration.setPutObjectModifier(modifierFunction);
+        Assert.assertEquals(configuration.getPutObjectModifier(), modifierFunction);
+    }
+
+    @Test
+    public void testPutObjectFunctioFluentApi()
+    {
+        SdkFunction<PutObjectRequest, PutObjectRequest> modifierFunction = new SdkFunction<PutObjectRequest, PutObjectRequest>() {
+            @Override
+            public PutObjectRequest apply(PutObjectRequest putObjectRequest) {
+                return null;
+            }
+        };
+
+        ExtendedClientConfiguration configuration = new ExtendedClientConfiguration().withPutObjectModifier(modifierFunction);
+        Assert.assertEquals(configuration.getPutObjectModifier(), modifierFunction);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
[10](https://github.com/awslabs/amazon-sqs-java-extended-client-lib/issues/10)

*Description of changes:*
Allow the client to pass in an implementation of the SdkFunction class from the core library, which takes a PutObjectRequest as the input and has the same return type. This will allow them to modify the put object request and add custom meta-data and any type of encryption.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
