### PR TITLE
support passing an ACL for S3 putObject operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-  <version>1.0.2</version>
+  <version>1.1.0-rc1</version>
   <packaging>jar</packaging>
   <name>Amazon SQS Extended Client Library for Java</name>
   <description>An extension to the Amazon SQS client that enables sending and receiving messages up to 2GB via Amazon S3.

--- a/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
@@ -17,6 +17,8 @@ package com.amazon.sqs.javamessaging;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import com.amazonaws.annotation.NotThreadSafe;
@@ -35,6 +37,9 @@ public class ExtendedClientConfiguration {
 	private String s3BucketName;
 	private boolean largePayloadSupport = false;
 	private boolean alwaysThroughS3 = false;
+	private AccessControlList acl;
+	private CannedAccessControlList cannedAcl;
+
 	private int messageSizeThreshold = SQSExtendedClientConstants.DEFAULT_MESSAGE_SIZE_THRESHOLD;
 
 	public ExtendedClientConfiguration() {
@@ -48,6 +53,8 @@ public class ExtendedClientConfiguration {
 		this.largePayloadSupport = other.largePayloadSupport;
 		this.alwaysThroughS3 = other.alwaysThroughS3;
 		this.messageSizeThreshold = other.messageSizeThreshold;
+		this.acl = other.acl;
+		this.cannedAcl = other.cannedAcl;
 	}
 
 	/**
@@ -214,4 +221,70 @@ public class ExtendedClientConfiguration {
 	public boolean isAlwaysThroughS3() {
 		return alwaysThroughS3;
 	}
+
+	/**
+	 * Sets an ACL Policy for S3 to be applied with PutObject operations.
+	 *
+	 * @param s3Acl
+	 * 				ACL Policy to apply when putting a large object in S3
+	 */
+	public void setS3Acl(AccessControlList s3Acl) {
+		acl = s3Acl;
+		LOG.info("ACL Policy for S3 put object operations set.");
+	}
+
+	/**
+	 * Sets an ACL Policy for S3 to be applied with PutObject operations.
+	 *
+	 * @param s3Acl
+	 * 				ACL Policy to apply when putting a large object in S3
+	 */
+	public ExtendedClientConfiguration withS3ACL(AccessControlList s3Acl) {
+		setS3Acl(s3Acl);
+		return this;
+	}
+
+	/**
+	 * Gets S3 ACL Policy configured
+	 *
+	 * @return ACL Policy configured
+	 *         S3. Default: Null.
+	 */
+	public AccessControlList getS3Acl() {
+		return acl;
+	}
+
+
+	/**
+	 * Sets a Canned ACL Policy for S3 to be applied with PutObject operations.
+	 *
+	 * @param s3CannedAcl
+	 * 				ACL Policy to apply when putting a large object in S3
+	 */
+	public void setS3CannedAcl(CannedAccessControlList s3CannedAcl) {
+		cannedAcl = s3CannedAcl;
+		LOG.info("ACL Policy for S3 put object operations set.");
+	}
+
+	/**
+	 * Sets a Canned ACL Policy for S3 to be applied with PutObject operations.
+	 *
+	 * @param s3CannedAcl
+	 * 				ACL Policy to apply when putting a large object in S3
+	 */
+	public ExtendedClientConfiguration withS3CannedACL(CannedAccessControlList s3CannedAcl) {
+		setS3CannedAcl(s3CannedAcl);
+		return this;
+	}
+
+	/**
+	 * Gets S3 Canned ACL Policy configured
+	 *
+	 * @return ACL Canned Policy configured
+	 *         S3. Default: Null.
+	 */
+	public CannedAccessControlList getS3CannedAcl() {
+		return cannedAcl;
+	}
+
 }

--- a/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/ExtendedClientConfigurationTest.java
@@ -16,6 +16,8 @@
 package com.amazon.sqs.javamessaging;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import junit.framework.Assert;
 import org.junit.Before;
@@ -116,5 +118,31 @@ public class ExtendedClientConfigurationTest {
 
     }
 
+    @Test
+    public void testS3ACL() {
+        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration();
 
+        Assert.assertNull(extendedClientConfiguration.getS3Acl());
+        AccessControlList acl = new AccessControlList();
+        extendedClientConfiguration.setS3Acl(acl);
+        Assert.assertEquals(acl, extendedClientConfiguration.getS3Acl());
+
+        extendedClientConfiguration = new ExtendedClientConfiguration()
+                .withS3ACL(acl);
+        Assert.assertEquals(acl, extendedClientConfiguration.getS3Acl());
+    }
+
+    @Test
+    public void testS3CannedACL() {
+        ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration();
+
+        Assert.assertNull(extendedClientConfiguration.getS3Acl());
+        CannedAccessControlList acl = CannedAccessControlList.BucketOwnerFullControl;
+        extendedClientConfiguration.setS3CannedAcl(acl);
+        Assert.assertEquals(acl, extendedClientConfiguration.getS3CannedAcl());
+
+        extendedClientConfiguration = new ExtendedClientConfiguration()
+                .withS3CannedACL(acl);
+        Assert.assertEquals(acl, extendedClientConfiguration.getS3CannedAcl());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I need to set specific ACLs for all objects in the bucket, otherwise they're rejected because of it's encryption policy.