### PR TITLE
Fix receiveMessage call to fetch correct message attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more information on using the amazon-sqs-java-extended-client-lib, see our g
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <type>jar</type>
   </dependency>
 ```   

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <packaging>jar</packaging>
   <name>Amazon SQS Extended Client Library for Java</name>
   <description>An extension to the Amazon SQS client that enables sending and receiving messages up to 2GB via Amazon S3.

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -322,7 +322,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
         List<String> messageAttributeNames = new ArrayList<>(receiveMessageRequest.messageAttributeNames());
         messageAttributeNames.removeAll(RESERVED_ATTRIBUTE_NAMES);
         messageAttributeNames.addAll(RESERVED_ATTRIBUTE_NAMES);
-        receiveMessageRequestBuilder.attributeNamesWithStrings(messageAttributeNames);
+        receiveMessageRequestBuilder.messageAttributeNames(messageAttributeNames);
         receiveMessageRequest = receiveMessageRequestBuilder.build();
 
         ReceiveMessageResponse receiveMessageResponse = super.receiveMessage(receiveMessageRequest);


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/amazon-sqs-java-extended-client-lib/issues/65

Description of changes:

Fix receiveMessage call to fetch correct message attributes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
