### PR TITLE
Closes the S3 client to avoid memory leak

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -1017,4 +1017,11 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
                                         .version(USER_AGENT_VERSION).build())
                                 .build());
     }
+
+	@Override
+	public void close() {
+		super.close();
+		this.clientConfiguration.getS3Client().close();
+	}    
+    
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During load test, we detected a memory leak due to the ExtendedClient closing only the SQS connection, but never closing the S3 connection, leading to the memory leak.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
