### PR TITLE
add support to set a prefix for the S3 key

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/ExtendedClientConfiguration.java
@@ -15,11 +15,17 @@
 
 package com.amazon.sqs.javamessaging;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import software.amazon.awssdk.annotations.NotThreadSafe;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.payloadoffloading.PayloadStorageConfiguration;
 import software.amazon.payloadoffloading.ServerSideEncryptionStrategy;
+
+import java.util.regex.Pattern;
 
 
 /**
@@ -28,10 +34,17 @@ import software.amazon.payloadoffloading.ServerSideEncryptionStrategy;
  */
 @NotThreadSafe
 public class ExtendedClientConfiguration extends PayloadStorageConfiguration {
+    private static final Log LOG = LogFactory.getLog(ExtendedClientConfiguration.class);
+
+    private static final int UUID_LENGTH = 36;
+    private static final int MAX_S3_KEY_LENGTH = 1024;
+    private static final int MAX_S3_KEY_PREFIX_LENGTH = MAX_S3_KEY_LENGTH - UUID_LENGTH;
+    private static final Pattern INVALID_S3_PREFIX_KEY_CHARACTERS_PATTERN = Pattern.compile("[^a-zA-Z0-9./_-]");
 
     private boolean cleanupS3Payload = true;
     private boolean useLegacyReservedAttributeName = true;
     private boolean ignorePayloadNotFound = false;
+    private String s3KeyPrefix = "";
 
     public ExtendedClientConfiguration() {
         super();
@@ -43,6 +56,7 @@ public class ExtendedClientConfiguration extends PayloadStorageConfiguration {
         this.cleanupS3Payload = other.doesCleanupS3Payload();
         this.useLegacyReservedAttributeName = other.usesLegacyReservedAttributeName();
         this.ignorePayloadNotFound = other.ignoresPayloadNotFound();
+        this.s3KeyPrefix = other.s3KeyPrefix;
     }
 
     /**
@@ -126,6 +140,63 @@ public class ExtendedClientConfiguration extends PayloadStorageConfiguration {
     public ExtendedClientConfiguration withIgnorePayloadNotFound(boolean ignorePayloadNotFound) {
         setIgnorePayloadNotFound(ignorePayloadNotFound);
         return this;
+    }
+
+    /**
+     * Sets a string that will be used as prefix of the S3 Key.
+     *
+     * @param s3KeyPrefix
+     *         A S3 key prefix value
+     */
+    public void setS3KeyPrefix(String s3KeyPrefix) {
+        String trimmedPrefix = StringUtils.trimToEmpty(s3KeyPrefix);
+
+        if (trimmedPrefix.length() > MAX_S3_KEY_PREFIX_LENGTH) {
+            String errorMessage = "The S3 key prefix length must not be greater than " + MAX_S3_KEY_PREFIX_LENGTH;
+            LOG.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+
+        if (trimmedPrefix.startsWith(".") || trimmedPrefix.startsWith("/")) {
+            String errorMessage = "The S3 key prefix must not starts with '.' or '/'";
+            LOG.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+
+        if (trimmedPrefix.contains("..")) {
+            String errorMessage = "The S3 key prefix must not contains the string '..'";
+            LOG.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+
+        if (INVALID_S3_PREFIX_KEY_CHARACTERS_PATTERN.matcher(trimmedPrefix).find()) {
+            String errorMessage = "The S3 key prefix contain invalid characters. The allowed characters are: letters, digits, '/', '_', '-', and '.'";
+            LOG.error(errorMessage);
+            throw SdkClientException.create(errorMessage);
+        }
+
+        this.s3KeyPrefix = trimmedPrefix;
+    }
+
+    /**
+     * Sets a string that will be used as prefix of the S3 Key.
+     *
+     * @param s3KeyPrefix
+     *         A S3 key prefix value
+     *
+     * @return the updated ExtendedClientConfiguration object.
+     */
+    public ExtendedClientConfiguration withS3KeyPrefix(String s3KeyPrefix) {
+        setS3KeyPrefix(s3KeyPrefix);
+        return this;
+    }
+
+    /**
+     * Gets the S3 key prefix
+     * @return the prefix value which is being used for compose the S3 key.
+     */
+    public String getS3KeyPrefix() {
+        return this.s3KeyPrefix;
     }
 
     /**

--- a/src/test/java/com/amazon/sqs/javamessaging/StringTestUtil.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/StringTestUtil.java
@@ -1,0 +1,11 @@
+package com.amazon.sqs.javamessaging;
+
+import java.util.Arrays;
+
+public class StringTestUtil {
+    public static String generateStringWithLength(int messageLength) {
+        char[] charArray = new char[messageLength];
+        Arrays.fill(charArray, 'x');
+        return new String(charArray);
+    }
+}


### PR DESCRIPTION
*Issue #7 *

*Description of changes:*

* This PR is adding an new attribute (`s3KeyPrefix`) for the ExtendedClientConfiguration class that will be used to compose the s3 key.
* When the s3KeyPrefix is not null or empty, the S3 key object will use this attribute as prefix of the key. For example, if the s3KeyPrefix is `queue-name/`, the S3 key will be something like `queue-name/676468c5-671f-4471-b9f6-fc5b0a5ab7de`.
* To keep the current behavior, the method `payloadStore.storeOriginalPayload(messageContentStr, s3Key)` will be used only if the s3KeyPrefix is not blank.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.