### PR TITLE
[Backport] add support to set a prefix for the S3 key #7

### DIFF
--- a/src/test/java/com/amazon/sqs/javamessaging/StringTestUtil.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/StringTestUtil.java
@@ -1,0 +1,11 @@
+package com.amazon.sqs.javamessaging;
+
+import java.util.Arrays;
+
+public class StringTestUtil {
+    public static String generateStringWithLength(int messageLength) {
+        char[] charArray = new char[messageLength];
+        Arrays.fill(charArray, 'x');
+        return new String(charArray);
+    }
+}


### PR DESCRIPTION
**IMPORTANT**: I'm backporting the [PR #118](https://github.com/awslabs/amazon-sqs-java-extended-client-lib/pull/118) to `v1`  branch.

*Issue https://github.com/awslabs/amazon-sqs-java-extended-client-lib/issues/7 *

Description of changes:

This PR is adding an new attribute (s3KeyPrefix) for the ExtendedClientConfiguration class that will be used to compose the s3 key.

When the s3KeyPrefix is not null or empty, the S3 key object will use this attribute as prefix of the key. For example, if the s3KeyPrefix is queue-name/, the S3 key will be something like queue-name/676468c5-671f-4471-b9f6-fc5b0a5ab7de.

To keep the current behavior, the method payloadStore.storeOriginalPayload(messageContentStr, s3Key) will be used only if the s3KeyPrefix is not blank.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.