### PR TITLE
Fix receive message operation for customers using older versions of Extended Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-  <version>1.2.5</version>
+  <version>1.2.6</version>
   <packaging>jar</packaging>
   <name>Amazon SQS Extended Client Library for Java</name>
   <description>An extension to the Amazon SQS client that enables sending and receiving messages up to 2GB via Amazon S3.

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -365,7 +365,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
             Optional<String> largePayloadAttributeName = getReservedAttributeNameIfPresent(message.getMessageAttributes());
             if (largePayloadAttributeName.isPresent()) {
                 String largeMessagePointer = message.getBody();
-                largeMessagePointer = largeMessagePointer.replace("com.amazon.sqs.javamessaging.MessageS3Pointer", "software.amazon.payloadoffloading.PayloadS3Pointer");
+                largeMessagePointer = largeMessagePointer.replaceFirst("com\\.(amazon|amazonaws)\\.(sqs|services)\\.(javamessaging|extendedmessaging).MessageS3Pointer", "software.amazon.payloadoffloading.PayloadS3Pointer");
 
                 final String originalBody;
                 try {


### PR DESCRIPTION
Fix receive message operation for customers using older versions of Extended Client

`mvn clean test` succeeds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
