### PR TITLE
Use batch payload delete, and properly chain deletes for async

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>amazon-sqs-java-extended-client-lib</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <packaging>jar</packaging>
   <name>Amazon SQS Extended Client Library for Java</name>
   <description>An extension to the Amazon SQS client that enables sending and receiving messages up to 2GB via Amazon S3.
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>software.amazon.payloadoffloading</groupId>
       <artifactId>payloadoffloading-common</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.1</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/commons-logging/commons-logging -->

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -698,6 +698,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
         }
 
         List<DeleteMessageBatchRequestEntry> entries = new ArrayList<>(deleteMessageBatchRequest.entries().size());
+        List<String> s3ToCleanup = new ArrayList<>(deleteMessageBatchRequest.entries().size());
         for (DeleteMessageBatchRequestEntry entry : deleteMessageBatchRequest.entries()) {
             DeleteMessageBatchRequestEntry.Builder entryBuilder = entry.toBuilder();
             String receiptHandle = entry.receiptHandle();
@@ -709,7 +710,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
                 // Delete s3 payload if needed
                 if (clientConfiguration.doesCleanupS3Payload()) {
                     String messagePointer = getMessagePointerFromModifiedReceiptHandle(receiptHandle);
-                    payloadStore.deleteOriginalPayload(messagePointer);
+                    s3ToCleanup.add(messagePointer);
                 }
             }
 
@@ -718,6 +719,11 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
         }
 
         deleteMessageBatchRequestBuilder.entries(entries);
+
+        if (!s3ToCleanup.isEmpty()) {
+            payloadStore.deleteOriginalPayloads(s3ToCleanup);
+        }
+
         return super.deleteMessageBatch(deleteMessageBatchRequestBuilder.build());
     }
 

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientTest.java
@@ -38,6 +38,8 @@ import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
@@ -91,6 +93,8 @@ public class AmazonSQSExtendedAsyncClientTest {
             CompletableFuture.completedFuture(null));
         when(mockS3.deleteObject(isA(DeleteObjectRequest.class))).thenReturn(
             CompletableFuture.completedFuture(DeleteObjectResponse.builder().build()));
+        when(mockS3.deleteObjects(isA(DeleteObjectsRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(DeleteObjectsResponse.builder().build()));
         when(mockSqsBackend.sendMessage(isA(SendMessageRequest.class))).thenReturn(
             CompletableFuture.completedFuture(SendMessageResponse.builder().build()));
         when(mockSqsBackend.sendMessageBatch(isA(SendMessageBatchRequest.class))).thenReturn(
@@ -590,7 +594,7 @@ public class AmazonSQSExtendedAsyncClientTest {
         IntStream.range(0, originalReceiptHandles.size()).forEach(i -> assertEquals(
             originalReceiptHandles.get(i),
             request.entries().get(i).receiptHandle()));
-        verify(mockS3, times(batchSize)).deleteObject(any(DeleteObjectRequest.class));
+        verify(mockS3, times(1)).deleteObjects(any(DeleteObjectsRequest.class));
     }
 
     @Test

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
@@ -621,7 +622,7 @@ public class AmazonSQSExtendedClientTest {
         IntStream.range(0, originalReceiptHandles.size()).forEach(i -> assertEquals(
             originalReceiptHandles.get(i),
             request.entries().get(i).receiptHandle()));
-        verify(mockS3, times(batchSize)).deleteObject(any(DeleteObjectRequest.class));
+        verify(mockS3, times(1)).deleteObjects(any(DeleteObjectsRequest.class));
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Two issues in the new async support were bothering me:

1. Order of operations between async and sync versions of the delete message operation were different. Sync deletes from S3 and then from SQS. Async deletes from SQS and then S3. This changes the async version of the code to match the original sync code.
2. In delete message batch, the delete futures for S3 were not chained into the delete future for SQS. In practice, this might not always cause a problem, but it is poor practice.

This pull request solves both problems by performing the delete-from-S3 and delete-from-SQS operations in the same order for both sync and async code, and by properly chaining them the same way for both.

Note that this new code makes use of a new feature in payload offloading, which deletes a batch of offloaded pointers from the store. This new feature is in this pull request: https://github.com/awslabs/payload-offloading-java-common-lib-for-aws/pull/57

Because that feature is only proposed right now, I am creating this as a draft PR for the time being.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
