### PR TITLE
Fix AmazonSQSExtendedAsyncClient ignoring the configured prefix

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClient.java
@@ -490,7 +490,7 @@ public class AmazonSQSExtendedAsyncClient extends AmazonSQSExtendedAsyncClientBa
                 clientConfiguration.usesLegacyReservedAttributeName()));
 
         // Store the message content in S3.
-        return payloadStore.storeOriginalPayload(messageContentStr)
+        return storeOriginalPayload(messageContentStr)
             .thenApply(largeMessagePointer -> {
                 sendMessageRequestBuilder.messageBody(largeMessagePointer);
                 return sendMessageRequestBuilder.build();


### PR DESCRIPTION
*Description of changes:*

AmazonSQSExtednedAsyncClient currently ignores the configured s3 prefix. I assume it's just a typo / oversight.
