### PR TITLE
Correct offloading of large batch entries to s3. Closes #154

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientUtil.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientUtil.java
@@ -101,10 +101,14 @@ public class AmazonSQSExtendedClientUtil {
         return (totalMsgSize > payloadSizeThreshold);
     }
 
+    public static long sizeOf(SendMessageBatchRequestEntry batchRequestEntry) {
+        int msgAttributesSize = getMsgAttributesSize(batchRequestEntry.messageAttributes());
+        long msgBodySize = Util.getStringSizeInBytes(batchRequestEntry.messageBody());
+        return msgAttributesSize + msgBodySize;
+    }
+
     public static boolean isLarge(int payloadSizeThreshold, SendMessageBatchRequestEntry batchEntry) {
-        int msgAttributesSize = getMsgAttributesSize(batchEntry.messageAttributes());
-        long msgBodySize = Util.getStringSizeInBytes(batchEntry.messageBody());
-        long totalMsgSize = msgAttributesSize + msgBodySize;
+        long totalMsgSize = sizeOf(batchEntry);
         return (totalMsgSize > payloadSizeThreshold);
     }
 


### PR DESCRIPTION
Fix Issue #154

Fix case when individual entries are under the threshold, but total batch size exceeds the threshold. Add test case covering the use-case, adjust old test that is now failing (wrong test-case)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
