### PR TITLE
Add IgnorepayloadNotFound flag support for SQSExtendedAsync Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,11 @@
       <version>5.12.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>LATEST</version>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClient.java
@@ -13,9 +13,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -193,6 +195,7 @@ public class AmazonSQSExtendedAsyncClient extends AmazonSQSExtendedAsyncClientBa
         messageAttributeNames.removeAll(AmazonSQSExtendedClientUtil.RESERVED_ATTRIBUTE_NAMES);
         messageAttributeNames.addAll(AmazonSQSExtendedClientUtil.RESERVED_ATTRIBUTE_NAMES);
         receiveMessageRequestBuilder.messageAttributeNames(messageAttributeNames);
+        String queueUrl = receiveMessageRequest.queueUrl();
         receiveMessageRequest = receiveMessageRequestBuilder.build();
 
         return super.receiveMessage(receiveMessageRequest)
@@ -222,7 +225,28 @@ public class AmazonSQSExtendedAsyncClient extends AmazonSQSExtendedAsyncClientBa
 
                         // Retrieve original payload
                         modifiedMessageFutures.add(payloadStore.getOriginalPayload(largeMessagePointer)
-                            .thenApply(originalPayload -> {
+                            .handle((originalPayload,throwable) -> {
+
+                                if(throwable != null)
+                                {
+                                    if(clientConfiguration.ignoresPayloadNotFound())
+                                    {
+                                        DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest
+                                                .builder()
+                                                .queueUrl(queueUrl)
+                                                .receiptHandle(message.receiptHandle())
+                                                .build();
+
+                                        deleteMessage(deleteMessageRequest).join();
+                                        LOG.warn("Message deleted from SQS since payload with pointer could not be found in S3.");
+                                        return null;
+                                    }
+                                    else
+                                    {
+                                        throw new CompletionException(throwable);
+                                    }
+                                }
+
                                 // Set original payload
                                 messageBuilder.body(originalPayload);
 
@@ -249,6 +273,7 @@ public class AmazonSQSExtendedAsyncClient extends AmazonSQSExtendedAsyncClientBa
                         modifiedMessageFutures.toArray(new CompletableFuture[modifiedMessageFutures.size()]))
                     .thenApply(v -> modifiedMessageFutures.stream()
                         .map(CompletableFuture::join)
+                        .filter(Objects::nonNull)
                         .collect(Collectors.toList()));
             })
             .thenApply(modifiedMessages -> {

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientTest.java
@@ -7,9 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -25,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,14 +38,17 @@ import software.amazon.awssdk.core.ApiName;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchResponse;
@@ -638,6 +644,63 @@ public class AmazonSQSExtendedAsyncClientTest {
         assertEquals(expectedMessage, actualMessage.body());
         assertFalse(actualMessage.messageAttributes().keySet().containsAll(AmazonSQSExtendedClientUtil.RESERVED_ATTRIBUTE_NAMES));
         verify(mockS3, times(1)).getObject(isA(GetObjectRequest.class), isA(AsyncResponseTransformer.class));
+    }
+
+    @Test
+    public void testReceiveMessage_when_ignorePayloadNotFound_then_messageWithPayloadNotFoundIsDeletedFromSQS() {
+        ExtendedAsyncClientConfiguration extendedAsyncClientConfiguration = new ExtendedAsyncClientConfiguration()
+                .withPayloadSupportEnabled(mockS3, S3_BUCKET_NAME)
+                .withIgnorePayloadNotFound(true);
+        SqsAsyncClient sqsAsyncExtended = spy(new AmazonSQSExtendedAsyncClient(mockSqsBackend, extendedAsyncClientConfiguration));
+
+        String receiptHandle = "receipt-handle";
+        Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, MessageAttributeValue.builder().build()))
+                .body(new PayloadS3Pointer(S3_BUCKET_NAME, "S3Key").toJson())
+                .receiptHandle(receiptHandle)
+                .build();
+
+        when(mockSqsBackend.receiveMessage(isA(ReceiveMessageRequest.class))).thenReturn(
+               CompletableFuture.completedFuture(ReceiveMessageResponse.builder().messages(message).build()));
+        doThrow(NoSuchKeyException.class).when(mockS3).getObject((GetObjectRequest) any(), any(AsyncResponseTransformer.class));
+
+        ReceiveMessageRequest messageRequest = ReceiveMessageRequest.builder().queueUrl(SQS_QUEUE_URL).build();
+        ReceiveMessageResponse receiveMessageResponse = sqsAsyncExtended.receiveMessage(messageRequest).join();
+
+        assertTrue(receiveMessageResponse.messages().isEmpty());
+
+        ArgumentCaptor<DeleteMessageRequest> deleteMessageRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageRequest.class);
+        verify(mockSqsBackend).deleteMessage(deleteMessageRequestArgumentCaptor.capture());
+        assertEquals(SQS_QUEUE_URL, deleteMessageRequestArgumentCaptor.getValue().queueUrl());
+        assertEquals(receiptHandle, deleteMessageRequestArgumentCaptor.getValue().receiptHandle());
+    }
+
+    @Test
+    public void testReceiveMessage_when_ignorePayloadNotFoundIsFalse_then_messageWithPayloadNotFoundThrowsException() {
+        ExtendedAsyncClientConfiguration extendedAsyncClientConfiguration = new ExtendedAsyncClientConfiguration()
+                .withPayloadSupportEnabled(mockS3, S3_BUCKET_NAME)
+                .withIgnorePayloadNotFound(false);
+        SqsAsyncClient sqsAsyncExtended = spy(new AmazonSQSExtendedAsyncClient(mockSqsBackend, extendedAsyncClientConfiguration));
+
+        String receiptHandle = "receipt-handle";
+        Message message = Message.builder()
+                .messageAttributes(ImmutableMap.of(SQSExtendedClientConstants.RESERVED_ATTRIBUTE_NAME, MessageAttributeValue.builder().build()))
+                .body(new PayloadS3Pointer(S3_BUCKET_NAME, "S3Key").toJson())
+                .receiptHandle(receiptHandle)
+                .build();
+
+        when(mockSqsBackend.receiveMessage(isA(ReceiveMessageRequest.class))).thenReturn(
+                CompletableFuture.completedFuture(ReceiveMessageResponse.builder().messages(message).build()));
+        doThrow(NoSuchKeyException.class).when(mockS3).getObject((GetObjectRequest) any(), any(AsyncResponseTransformer.class));
+
+        ReceiveMessageRequest messageRequest = ReceiveMessageRequest.builder().build();
+        try {
+            sqsAsyncExtended.receiveMessage(messageRequest).join();
+            fail("Expected exception after receiving NoSuchKeyException from S3 was not thrown.");
+        } catch (CompletionException e) {
+            assertEquals(NoSuchKeyException.class.getName(), e.getCause().getClass().getName());
+            verify(mockSqsBackend, never()).deleteMessage(any(DeleteMessageRequest.class));
+        }
     }
 
     private DeleteMessageBatchRequest generateLargeDeleteBatchRequest(List<String> originalReceiptHandles) {

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -67,9 +67,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -719,12 +721,12 @@ public class AmazonSQSExtendedClientTest {
         ReceiveMessageRequest messageRequest = ReceiveMessageRequest.builder().queueUrl(SQS_QUEUE_URL).build();
         ReceiveMessageResponse receiveMessageResponse = sqsExtended.receiveMessage(messageRequest);
 
-        Assert.assertTrue(receiveMessageResponse.messages().isEmpty());
+        assertTrue(receiveMessageResponse.messages().isEmpty());
 
         ArgumentCaptor<DeleteMessageRequest> deleteMessageRequestArgumentCaptor = ArgumentCaptor.forClass(DeleteMessageRequest.class);
         verify(mockSqsBackend).deleteMessage(deleteMessageRequestArgumentCaptor.capture());
-        Assert.assertEquals(SQS_QUEUE_URL, deleteMessageRequestArgumentCaptor.getValue().queueUrl());
-        Assert.assertEquals(receiptHandle, deleteMessageRequestArgumentCaptor.getValue().receiptHandle());
+        assertEquals(SQS_QUEUE_URL, deleteMessageRequestArgumentCaptor.getValue().queueUrl());
+        assertEquals(receiptHandle, deleteMessageRequestArgumentCaptor.getValue().receiptHandle());
     }
 
     @Test

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -706,6 +706,7 @@ public class AmazonSQSExtendedClientTest {
         ExtendedClientConfiguration extendedClientConfiguration = new ExtendedClientConfiguration()
                 .withPayloadSupportEnabled(mockS3, S3_BUCKET_NAME)
                 .withIgnorePayloadNotFound(true);
+
         SqsClient sqsExtended = spy(new AmazonSQSExtendedClient(mockSqsBackend, extendedClientConfiguration));
 
         String receiptHandle = "receipt-handle";
@@ -716,6 +717,7 @@ public class AmazonSQSExtendedClientTest {
                 .build();
 
         when(mockSqsBackend.receiveMessage(isA(ReceiveMessageRequest.class))).thenReturn(ReceiveMessageResponse.builder().messages(message).build());
+
         doThrow(NoSuchKeyException.class).when(mockS3).getObject(any(GetObjectRequest.class));
 
         ReceiveMessageRequest messageRequest = ReceiveMessageRequest.builder().queueUrl(SQS_QUEUE_URL).build();


### PR DESCRIPTION

*Description of changes:*
- Add bytebuddy dependency to support inline Mockito tests
- Fix test cases for SQSExtendedClient
- Add IgnorePayload flag support for SQSExtendedAsyncClient and test cases related to it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
