### PR TITLE
Fix bytebuddy library scope to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
       <version>LATEST</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
*Description of changes:*

Byebuddy (A test library) should be not be direct dependency, this change also reduces Jar size.
default scope is compile so changing it to test.

<img width="831" alt="Screenshot 2025-06-10 at 11 44 25" src="https://github.com/user-attachments/assets/706112f1-0567-49c8-b33e-c110c166509a" />

https://central.sonatype.com/artifact/com.amazonaws/amazon-sqs-java-extended-client-lib/dependencies

