### PR TITLE
Delegate ReDrive APIs to the underlying SQS client

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientBase.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientBase.java
@@ -4,6 +4,8 @@ import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.AddPermissionRequest;
 import software.amazon.awssdk.services.sqs.model.AddPermissionResponse;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
@@ -22,6 +24,8 @@ import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse;
 import software.amazon.awssdk.services.sqs.model.ListDeadLetterSourceQueuesRequest;
 import software.amazon.awssdk.services.sqs.model.ListDeadLetterSourceQueuesResponse;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksRequest;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksResponse;
 import software.amazon.awssdk.services.sqs.model.ListQueueTagsRequest;
 import software.amazon.awssdk.services.sqs.model.ListQueueTagsResponse;
 import software.amazon.awssdk.services.sqs.model.ListQueuesRequest;
@@ -38,6 +42,8 @@ import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest;
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesResponse;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskResponse;
 import software.amazon.awssdk.services.sqs.model.TagQueueRequest;
 import software.amazon.awssdk.services.sqs.model.TagQueueResponse;
 import software.amazon.awssdk.services.sqs.model.UntagQueueRequest;
@@ -224,6 +230,33 @@ abstract class AmazonSQSExtendedAsyncClientBase implements SqsAsyncClient {
     @Override
     public CompletableFuture<UntagQueueResponse> untagQueue(final UntagQueueRequest untagQueueRequest) {
         return amazonSqsToBeExtended.untagQueue(untagQueueRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<StartMessageMoveTaskResponse> startMessageMoveTask(
+            StartMessageMoveTaskRequest startMessageMoveTaskRequest) {
+        return amazonSqsToBeExtended.startMessageMoveTask(startMessageMoveTaskRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<ListMessageMoveTasksResponse> listMessageMoveTasks(
+            ListMessageMoveTasksRequest listMessageMoveTasksRequest) {
+        return amazonSqsToBeExtended.listMessageMoveTasks(listMessageMoveTasksRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CompletableFuture<CancelMessageMoveTaskResponse> cancelMessageMoveTask(
+            CancelMessageMoveTaskRequest cancelMessageMoveTaskRequest) {
+        return amazonSqsToBeExtended.cancelMessageMoveTask(cancelMessageMoveTaskRequest);
     }
 
     /**

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientBase.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientBase.java
@@ -25,6 +25,8 @@ import software.amazon.awssdk.services.sqs.model.AddPermissionRequest;
 import software.amazon.awssdk.services.sqs.model.AddPermissionResponse;
 import software.amazon.awssdk.services.sqs.model.BatchEntryIdsNotDistinctException;
 import software.amazon.awssdk.services.sqs.model.BatchRequestTooLongException;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
@@ -48,6 +50,8 @@ import software.amazon.awssdk.services.sqs.model.InvalidIdFormatException;
 import software.amazon.awssdk.services.sqs.model.InvalidMessageContentsException;
 import software.amazon.awssdk.services.sqs.model.ListDeadLetterSourceQueuesRequest;
 import software.amazon.awssdk.services.sqs.model.ListDeadLetterSourceQueuesResponse;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksRequest;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksResponse;
 import software.amazon.awssdk.services.sqs.model.ListQueueTagsRequest;
 import software.amazon.awssdk.services.sqs.model.ListQueueTagsResponse;
 import software.amazon.awssdk.services.sqs.model.ListQueuesRequest;
@@ -72,6 +76,8 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest;
 import software.amazon.awssdk.services.sqs.model.SetQueueAttributesResponse;
 import software.amazon.awssdk.services.sqs.model.SqsException;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskResponse;
 import software.amazon.awssdk.services.sqs.model.TagQueueRequest;
 import software.amazon.awssdk.services.sqs.model.TagQueueResponse;
 import software.amazon.awssdk.services.sqs.model.TooManyEntriesInBatchRequestException;
@@ -1110,6 +1116,27 @@ abstract class AmazonSQSExtendedClientBase implements SqsClient {
     /** {@inheritDoc} */
     @Override public UntagQueueResponse untagQueue(final UntagQueueRequest untagQueueRequest) {
         return amazonSqsToBeExtended.untagQueue(untagQueueRequest);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public StartMessageMoveTaskResponse startMessageMoveTask(
+            StartMessageMoveTaskRequest startMessageMoveTaskRequest) {
+        return amazonSqsToBeExtended.startMessageMoveTask(startMessageMoveTaskRequest);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ListMessageMoveTasksResponse listMessageMoveTasks(
+            ListMessageMoveTasksRequest listMessageMoveTasksRequest) {
+        return amazonSqsToBeExtended.listMessageMoveTasks(listMessageMoveTasksRequest);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public CancelMessageMoveTaskResponse cancelMessageMoveTask(
+            CancelMessageMoveTaskRequest cancelMessageMoveTaskRequest) {
+        return amazonSqsToBeExtended.cancelMessageMoveTask(cancelMessageMoveTaskRequest);
     }
 
     @Override

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientTest.java
@@ -58,11 +58,17 @@ import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskResponse;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksRequest;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskResponse;
 import software.amazon.awssdk.utils.ImmutableMap;
 import software.amazon.payloadoffloading.PayloadS3Pointer;
 import software.amazon.payloadoffloading.ServerSideEncryptionFactory;
@@ -701,6 +707,55 @@ public class AmazonSQSExtendedAsyncClientTest {
             assertEquals(NoSuchKeyException.class.getName(), e.getCause().getClass().getName());
             verify(mockSqsBackend, never()).deleteMessage(any(DeleteMessageRequest.class));
         }
+    }
+
+    @Test
+    public void testStartMessageMoveTaskDelegatesToUnderlyingClient() {
+        StartMessageMoveTaskRequest request = StartMessageMoveTaskRequest.builder()
+                .sourceArn("arn:aws:sqs:us-east-1:123456789012:source-dlq")
+                .build();
+        StartMessageMoveTaskResponse expectedResponse = StartMessageMoveTaskResponse.builder()
+                .taskHandle("task-handle")
+                .build();
+        when(mockSqsBackend.startMessageMoveTask(isA(StartMessageMoveTaskRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        StartMessageMoveTaskResponse response = extendedSqsWithDefaultConfig.startMessageMoveTask(request).join();
+
+        assertEquals(expectedResponse, response);
+        verify(mockSqsBackend).startMessageMoveTask(request);
+    }
+
+    @Test
+    public void testListMessageMoveTasksDelegatesToUnderlyingClient() {
+        ListMessageMoveTasksRequest request = ListMessageMoveTasksRequest.builder()
+                .sourceArn("arn:aws:sqs:us-east-1:123456789012:source-dlq")
+                .build();
+        ListMessageMoveTasksResponse expectedResponse = ListMessageMoveTasksResponse.builder().build();
+        when(mockSqsBackend.listMessageMoveTasks(isA(ListMessageMoveTasksRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        ListMessageMoveTasksResponse response = extendedSqsWithDefaultConfig.listMessageMoveTasks(request).join();
+
+        assertEquals(expectedResponse, response);
+        verify(mockSqsBackend).listMessageMoveTasks(request);
+    }
+
+    @Test
+    public void testCancelMessageMoveTaskDelegatesToUnderlyingClient() {
+        CancelMessageMoveTaskRequest request = CancelMessageMoveTaskRequest.builder()
+                .taskHandle("task-handle")
+                .build();
+        CancelMessageMoveTaskResponse expectedResponse = CancelMessageMoveTaskResponse.builder()
+                .approximateNumberOfMessagesMoved(42L)
+                .build();
+        when(mockSqsBackend.cancelMessageMoveTask(isA(CancelMessageMoveTaskRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CancelMessageMoveTaskResponse response = extendedSqsWithDefaultConfig.cancelMessageMoveTask(request).join();
+
+        assertEquals(expectedResponse, response);
+        verify(mockSqsBackend).cancelMessageMoveTask(request);
     }
 
     private DeleteMessageBatchRequest generateLargeDeleteBatchRequest(List<String> originalReceiptHandles) {

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientTest.java
@@ -39,6 +39,10 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.CancelMessageMoveTaskResponse;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksRequest;
+import software.amazon.awssdk.services.sqs.model.ListMessageMoveTasksResponse;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -46,6 +50,8 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskRequest;
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskResponse;
 import software.amazon.awssdk.utils.ImmutableMap;
 import software.amazon.awssdk.utils.StringInputStream;
 import software.amazon.payloadoffloading.PayloadS3Pointer;
@@ -755,6 +761,55 @@ public class AmazonSQSExtendedClientTest {
             assertEquals(NoSuchKeyException.class.getName(), e.getCause().getClass().getName());
             verify(mockSqsBackend, never()).deleteMessage(any(DeleteMessageRequest.class));
         }
+    }
+
+    @Test
+    public void testStartMessageMoveTaskDelegatesToUnderlyingClient() {
+        StartMessageMoveTaskRequest request = StartMessageMoveTaskRequest.builder()
+                .sourceArn("arn:aws:sqs:us-east-1:123456789012:source-dlq")
+                .build();
+        StartMessageMoveTaskResponse expectedResponse = StartMessageMoveTaskResponse.builder()
+                .taskHandle("task-handle")
+                .build();
+        when(mockSqsBackend.startMessageMoveTask(isA(StartMessageMoveTaskRequest.class)))
+                .thenReturn(expectedResponse);
+
+        StartMessageMoveTaskResponse response = extendedSqsWithDefaultConfig.startMessageMoveTask(request);
+
+        assertEquals(expectedResponse, response);
+        verify(mockSqsBackend).startMessageMoveTask(request);
+    }
+
+    @Test
+    public void testListMessageMoveTasksDelegatesToUnderlyingClient() {
+        ListMessageMoveTasksRequest request = ListMessageMoveTasksRequest.builder()
+                .sourceArn("arn:aws:sqs:us-east-1:123456789012:source-dlq")
+                .build();
+        ListMessageMoveTasksResponse expectedResponse = ListMessageMoveTasksResponse.builder().build();
+        when(mockSqsBackend.listMessageMoveTasks(isA(ListMessageMoveTasksRequest.class)))
+                .thenReturn(expectedResponse);
+
+        ListMessageMoveTasksResponse response = extendedSqsWithDefaultConfig.listMessageMoveTasks(request);
+
+        assertEquals(expectedResponse, response);
+        verify(mockSqsBackend).listMessageMoveTasks(request);
+    }
+
+    @Test
+    public void testCancelMessageMoveTaskDelegatesToUnderlyingClient() {
+        CancelMessageMoveTaskRequest request = CancelMessageMoveTaskRequest.builder()
+                .taskHandle("task-handle")
+                .build();
+        CancelMessageMoveTaskResponse expectedResponse = CancelMessageMoveTaskResponse.builder()
+                .approximateNumberOfMessagesMoved(42L)
+                .build();
+        when(mockSqsBackend.cancelMessageMoveTask(isA(CancelMessageMoveTaskRequest.class)))
+                .thenReturn(expectedResponse);
+
+        CancelMessageMoveTaskResponse response = extendedSqsWithDefaultConfig.cancelMessageMoveTask(request);
+
+        assertEquals(expectedResponse, response);
+        verify(mockSqsBackend).cancelMessageMoveTask(request);
     }
 
     private DeleteMessageBatchRequest generateLargeDeleteBatchRequest(List<String> originalReceiptHandles) {


### PR DESCRIPTION
## Issue

`AmazonSQSExtendedClientBase` and `AmazonSQSExtendedAsyncClientBase` do not override `startMessageMoveTask`, `listMessageMoveTasks`, or `cancelMessageMoveTask`. Calls fall through to the `SqsClient` / `SqsAsyncClient` interface default methods, which throw `UnsupportedOperationException`, breaking DLQ redrive for any consumer that wraps an SQS client with the extended client for S3 payload offloading.

## Reproduction

```java
SqsAsyncClient extended = new AmazonSQSExtendedAsyncClient(
    SqsAsyncClient.create(),
    new ExtendedAsyncClientConfiguration().withPayloadSupportEnabled(s3, bucket));

extended.startMessageMoveTask(r -> r.sourceArn(dlqArn)).join();
// java.lang.UnsupportedOperationException: startMessageMoveTask
```

## Fix

Add plain delegating overrides in both base classes. These server-side move operations don't interact with message payloads, so no extended-client-specific handling is required.

## Prior art

This mirrors the equivalent fix landed for the v1 SDK branch in [f0959cb](https://github.com/awslabs/amazon-sqs-java-extended-client-lib/commit/f0959cb17cd77d6f95a6a16b3267db20d10b6b58).

## Tests

Added one delegation test per method in both `AmazonSQSExtendedClientTest` and `AmazonSQSExtendedAsyncClientTest`. All 94 tests pass locally.
