### PR TITLE
feat: Add pass-through implementations for serviceClientConfiguration()

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientBase.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClientBase.java
@@ -2,6 +2,7 @@ package com.amazon.sqs.javamessaging;
 
 import java.util.concurrent.CompletableFuture;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsServiceClientConfiguration;
 import software.amazon.awssdk.services.sqs.model.AddPermissionRequest;
 import software.amazon.awssdk.services.sqs.model.AddPermissionResponse;
 import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityBatchRequest;
@@ -224,6 +225,14 @@ abstract class AmazonSQSExtendedAsyncClientBase implements SqsAsyncClient {
     @Override
     public CompletableFuture<UntagQueueResponse> untagQueue(final UntagQueueRequest untagQueueRequest) {
         return amazonSqsToBeExtended.untagQueue(untagQueueRequest);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SqsServiceClientConfiguration serviceClientConfiguration() {
+        return amazonSqsToBeExtended.serviceClientConfiguration();
     }
 
     /**

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientBase.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientBase.java
@@ -21,6 +21,7 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsServiceClientConfiguration;
 import software.amazon.awssdk.services.sqs.model.AddPermissionRequest;
 import software.amazon.awssdk.services.sqs.model.AddPermissionResponse;
 import software.amazon.awssdk.services.sqs.model.BatchEntryIdsNotDistinctException;
@@ -1110,6 +1111,11 @@ abstract class AmazonSQSExtendedClientBase implements SqsClient {
     /** {@inheritDoc} */
     @Override public UntagQueueResponse untagQueue(final UntagQueueRequest untagQueueRequest) {
         return amazonSqsToBeExtended.untagQueue(untagQueueRequest);
+    }
+
+    /** {@inheritDoc} */
+    @Override public SqsServiceClientConfiguration serviceClientConfiguration() {
+        return amazonSqsToBeExtended.serviceClientConfiguration();
     }
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We're using `AmazonSqsExtendedClient` from this library, and we have a use case that needs the region of the client post construction. This can usually be looked up using `sqsClient.serviceClientConfiguration().region()` with a standard client, but `AmazonSqsExtendedClient` doesn't pass through the invocation to the underlying client. Instead, the `default` implementation on the `SqsClient` interface is used, which throws an `UnsupportedOperationException`.

This PR adds pass-through implementations for `serviceClientConfiguration()` to `AmazonSQSExtendedClientBase` (and its async equivalence) which actually invokes the underlying `amazonSqsToBeExtended.serviceClientConfiguration()` which might provide a concrete implementation for this. method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
