### PR TITLE
Increase message size to 1 MiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Amazon SQS Extended Client Library for Java
 ===========================================
-The **Amazon SQS Extended Client Library for Java** enables you to manage Amazon SQS message payloads with Amazon S3. This is especially useful for storing and retrieving messages with a message payload size greater than the current SQS limit of 256 KB, up to a maximum of 2 GB. Specifically, you can use this library to:
+The **Amazon SQS Extended Client Library for Java** enables you to manage Amazon SQS message payloads with Amazon S3. This is especially useful for storing and retrieving messages with a message payload size greater than the current SQS limit of 1 MiB, up to a maximum of 2 GB. Specifically, you can use this library to:
 
-* Specify whether message payloads are always stored in Amazon S3 or only when a message's size exceeds 256 KB.
+* Specify whether message payloads are always stored in Amazon S3 or only when a message's size exceeds 1 MiB.
 
 * Send a message that references a single message object stored in an Amazon S3 bucket.
 

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedAsyncClient.java
@@ -70,7 +70,7 @@ import software.amazon.payloadoffloading.Util;
  *
  * <ul>
  * <li>Specify whether messages are always stored in Amazon S3 or only when a
- * message size exceeds 256 KB.</li>
+ * message size exceeds 1 MiB.</li>
  * <li>Send a message that references a single message object stored in an
  * Amazon S3 bucket.</li>
  * <li>Get the corresponding message object from an Amazon S3 bucket.</li>

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClient.java
@@ -93,7 +93,7 @@ import software.amazon.payloadoffloading.Util;
  *
  * <ul>
  * <li>Specify whether messages are always stored in Amazon S3 or only when a
- * message size exceeds 256 KB.</li>
+ * message size exceeds 1 MiB.</li>
  * <li>Send a message that references a single message object stored in an
  * Amazon S3 bucket.</li>
  * <li>Get the corresponding message object from an Amazon S3 bucket.</li>
@@ -559,7 +559,7 @@ public class AmazonSQSExtendedClient extends AmazonSQSExtendedClientBase impleme
      * </p>
      * <p>
      * The maximum allowed individual message size and the maximum total payload size (the sum of the individual lengths
-     * of all of the batched messages) are both 256 KB (262,144 bytes).
+     * of all of the batched messages) are both 1 MiB (1,048,576 bytes).
      * </p>
      * <important>
      * <p>

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientBase.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSExtendedClientBase.java
@@ -596,7 +596,7 @@ abstract class AmazonSQSExtendedClientBase implements SqsClient {
      * </p>
      * <p>
      * The maximum allowed individual message size and the maximum total payload size (the sum of the individual lengths
-     * of all of the batched messages) are both 256 KB (262,144 bytes).
+     * of all of the batched messages) are both 1 MiB (1,048,576 bytes).
      * </p>
      * <important>
      * <p>

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSExtendedClientConstants.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSExtendedClientConstants.java
@@ -29,7 +29,7 @@ public class SQSExtendedClientConstants {
 
     // This constant is shared with SNSExtendedClient
     // SNS team should be notified of any changes made to this
-    public static final int DEFAULT_MESSAGE_SIZE_THRESHOLD = 262144;
+    public static final int DEFAULT_MESSAGE_SIZE_THRESHOLD = 1048576;
 
     public static final String S3_BUCKET_NAME_MARKER = "-..s3BucketName..-";
     public static final String S3_KEY_MARKER = "-..s3Key..-";


### PR DESCRIPTION
*Issue #, if available:*

Since AWS SQS has changed max payload size to 1 MiB updating threshold limit.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
